### PR TITLE
Enable systemd services for Pelion Edge components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 scripts/config.txt
 scripts/interfaces
 scripts/wpa_supplicant.conf
+recipes-wigwag/mbed-edge-core/files/mbed_cloud_dev_credentials.c
+recipes-wigwag/mbed-edge-core/files/update_default_resources.c
+recipes-core/ww-console-image-initramfs-init/files/upgradeCA.cert

--- a/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
+++ b/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 RDEPENDS_${PN}+="bash"
 
-inherit pkgconfig gitpkgv update-rc.d
+inherit pkgconfig gitpkgv update-rc.d systemd
 
 INITSCRIPT_NAME = "deviceOS-watchdog"
 INITSCRIPT_PARAMS = "defaults 60 40"
@@ -64,6 +64,7 @@ do_compile() {
     cp deviceOSWD deviceOSWD_rpi_3bplus
 }
 
+SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "deviceos-wd.service"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 

--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -1,7 +1,7 @@
 [Unit]
 Descritpion=Maestro: Network, Config, DeviceJS manager
-Requires=deviceos-wd
-After=deviceos-wd
+Requires=deviceos-wd.service
+After=deviceos-wd.service
 
 [Service]
 Environment="LD_LIBRARY_PATH=/wigwag/system/lib"

--- a/recipes-wigwag/maestro/maestro_0.0.1.bb
+++ b/recipes-wigwag/maestro/maestro_0.0.1.bb
@@ -6,11 +6,14 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=1dece7821bf3fd70fe1309ea
 
 DEPENDS="deviceos-users"
 RDEPENDS_${PN}+="bash twlib"
-inherit go pkgconfig gitpkgv update-rc.d
+inherit go pkgconfig gitpkgv update-rc.d systemd
 
 INITSCRIPT_NAME = "maestro.sh"
 INITSCRIPT_PARAMS = "defaults 85 15"
 
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "maestro.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
 CGO_ENABLED = "1"
 

--- a/recipes-wigwag/mbed-edge-core/files/edge-core.service
+++ b/recipes-wigwag/mbed-edge-core/files/edge-core.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = Edge Core
+
+[Service]
+ExecStartPre=mkdir -p /userdata/mbed
+ExecStartPre=chown developer -R /userdata/mbed
+ExecStart=/wigwag/mbed/edge-core  --http-port 9101
+
+[Install]
+RequiredBy=network.target

--- a/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
@@ -14,6 +14,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI = "git://git@github.com/ARMmbed/mbed-edge.git;protocol=ssh; \
            file://edge-core.init \
+           file://edge-core.service \
            file://edge-core.logrotate \
            file://toolchain.cmake \
            file://0001-disable-Doxygen.patch \
@@ -49,10 +50,13 @@ EXTRA_OECMAKE += " \
     -DBYOC_MODE=${MBED_EDGE_CORE_CONFIG_BYOC_MODE} \
     ${MBED_EDGE_CORE_CUSTOM_CMAKE_ARGUMENTS}"
 
-inherit cmake update-rc.d
+inherit cmake update-rc.d systemd
 
 INITSCRIPT_NAME = "mbed-edge-core"
 INITSCRIPT_PARAMS = "defaults 85 15"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "edge-core.service"
 
 do_configure_prepend() {
     cd ${S}
@@ -69,6 +73,9 @@ do_configure_prepend() {
 do_install() {
     install -d "${D}/etc/init.d/"
     install -m 755 "${WORKDIR}/edge-core.init" "${D}/etc/init.d/${INITSCRIPT_NAME}"
+
+    install -d "${D}${systemd_system_unitdir}"
+    install -m 755 "${WORKDIR}/edge-core.service" "${D}${systemd_system_unitdir}/edge-core.service"
 
     install -d "${D}/wigwag/mbed/"
     install "${WORKDIR}/build/bin/edge-core" "${D}/wigwag/mbed/"

--- a/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
+++ b/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
@@ -3,11 +3,13 @@ DESCRIPTION = "Utilities used by the WigWag Relay"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
-SRC_URI="git://git@github.com/armPelionEdge/edge-utils.git;protocol=ssh;name=wwrelay \
-git://git@github.com/armPelionEdge/edgeos-shell-scripts.git;protocol=ssh;name=dss;destsuffix=git/dss \
-file://wwrelay \
-file://BUILDMMU.txt \
-file://logrotate_directives/ \
+SRC_URI="\
+  git://git@github.com/armPelionEdge/edge-utils.git;protocol=ssh;name=wwrelay \
+  git://git@github.com/armPelionEdge/edgeos-shell-scripts.git;protocol=ssh;name=dss;destsuffix=git/dss \
+  git://git@github.com/armPelionEdge/node-i2c.git;protocol=ssh;name=node_i2c;destsuffix=git/tempI2C/node-i2c \
+  file://wwrelay \
+  file://BUILDMMU.txt \
+  file://logrotate_directives/ \
 "
 
 SRCREV_FORMAT = "wwrelay-dss"
@@ -84,16 +86,7 @@ do_compile() {
 	make all
 
 	do_log "I2c"
-	cd ${S}
-	cd ..
-	if [[ -e tempI2C ]]; then
-		rm -rf tempI2C/
-	fi
-	mkdir tempI2C
-	cd tempI2C
-	git clone -b master git@github.com:armPelionEdge/node-i2c.git
-	git -C node-i2c checkout ${SRCREV_node_i2c}
-	cd node-i2c
+	cd ${S}/tempI2C/node-i2c
 	do_log "in wwrelay-utils node-i2c"
 	oe_runnpm install --target_arch=arm --production
 	node-gyp configure
@@ -104,26 +97,26 @@ do_compile() {
 	sed -i -- "/node-i2c/d" package.json
 	oe_runnpm install  --target_arch=arm --production
 	cd node_modules
-	cp -r ${S}/../tempI2C/node-i2c/ i2c
+	cp -r ${S}/tempI2C/node-i2c/ i2c
 
 	do_log "GPIO"
 	cd ${S}/GPIO
 	oe_runnpm install --production
 	make
 
-do_log "slip-radio"
-cd ${S}/slip-radio
-oe_runnpm install --production
+  do_log "slip-radio"
+  cd ${S}/slip-radio
+  oe_runnpm install --production
 
-do_log "slipcoms"
-cd ${S}/slipcomms 
-make 
+  do_log "slipcoms"
+  cd ${S}/slipcomms
+  make
 
-do_log "cc2530prog"
-cd ${S}/cc2530prog
-make
+  do_log "cc2530prog"
+  cd ${S}/cc2530prog
+  make
 
-cd ${S}
+  cd ${S}
 
 }
 
@@ -132,8 +125,7 @@ do_dirInstall(){
 	cd $1
 	find . -type d -exec install -d $2/{} \;
 	find . -type f -exec install -m 0755 {} $2/{} \; 
-#a more cleaver one:
-popd >> /dev/null
+  popd >> /dev/null
 }
 
 


### PR DESCRIPTION
Components enabled so far:
 - [x] edge-core
 - [x] deviceos-wd
 - [x] maestro
 - [ ] create-new-eeprom-with-self-signed-certs.sh (probably going to
       name it something else)
 - [ ] wwrelay-utils