### PR TITLE
Allow Maestro to start without deviceos-wd

### DIFF
--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -1,7 +1,5 @@
 [Unit]
 Descritpion=Maestro: Network, Config, DeviceJS manager
-Requires=deviceos-wd.service
-After=deviceos-wd.service
 
 [Service]
 Restart=always


### PR DESCRIPTION
Previously, maestro.service required deviceos-wd.service. This
creates an untracked dependency between `maestro` and `deviceos-wd`.

After some experimentation, we found that maestro does not need
a running deviceos-wd to start correctly. This commit breaks this
untracked dependency and allows another development board to boot,
as it does not have a working watchdog.