### PR TITLE
Drop `-linkshared` from devicedb build

### DIFF
--- a/recipes-wigwag/devicedb/devicedb_0.0.12.bb
+++ b/recipes-wigwag/devicedb/devicedb_0.0.12.bb
@@ -1,6 +1,8 @@
 DESCRIPTION = "devicedb distributed database"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=58b1e0eba1968eab8a0f46444674102a"
+# avoid the `-linkshared` option in this recipe as it causes a panic
+GO_LINKSHARED=""
 
 inherit go pkgconfig gitpkgv
 


### PR DESCRIPTION
Perviously, devicedb would build with `-linkshared` and that would
cause it to panic with `fatal error: sweep increased allocation count`.

This commit works around the issue by removing `-linkshared`

Implementation notes: This uses the `GO_LINKSHARED` vairable within the
bitbake class.