### PR TITLE
Depend on global-node-modules

### DIFF
--- a/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
+++ b/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
@@ -36,7 +36,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r7"
 
 DEPENDS = "update-rc.d-native nodejs nodejs-native"
-RDEPENDS_${PN} += " bash nodejs openssl10"
+RDEPENDS_${PN} += " bash nodejs openssl10 global-node-modules"
 
 FILES_${PN} = "\
   /wigwag/*\


### PR DESCRIPTION
A script in edge-utils, called by the wait-for-pelion-identity service
depends on the installation of global-node-modules. This codifies that
information.