### PR TITLE
Created new mcc user configuration for edge-core when compiled for Pe…

### DIFF
--- a/recipes-wigwag/mbed-edge-core/files/edge_gw_mcc_user_config.h
+++ b/recipes-wigwag/mbed-edge-core/files/edge_gw_mcc_user_config.h
@@ -1,0 +1,41 @@
+/*
+ * ----------------------------------------------------------------------------
+ * Copyright 2019 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+/*
+ * Minimal configuration for using mbed-cloud-client
+ */
+
+#ifndef MBED_CLOUD_CLIENT_USER_CONFIG_H
+#define MBED_CLOUD_CLIENT_USER_CONFIG_H
+
+#define MBED_CLOUD_CLIENT_SUPPORT_CLOUD
+#define MBED_CLOUD_CLIENT_ENDPOINT_TYPE          "EDGE_GW"
+#define MBED_CLOUD_CLIENT_TRANSPORT_MODE_UDP
+#define MBED_CLOUD_CLIENT_LIFETIME               600
+
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE       1024
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT       50
+
+#define MBED_CONF_MBED_CLIENT_SN_COAP_RESENDING_QUEUE_SIZE_MSGS 50
+
+/* set download buffer size in bytes (min. 1024 bytes) */
+#define MBED_CLOUD_CLIENT_UPDATE_BUFFER          (2 * 1024 * 1024)
+
+#endif /* MBED_CLIENT_USER_CONFIG_H */

--- a/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
@@ -17,6 +17,7 @@ SRC_URI = "git://git@github.com/ARMmbed/mbed-edge.git;protocol=ssh; \
            file://edge-core.service \
            file://edge-core.logrotate \
            file://toolchain.cmake \
+           file://edge_gw_mcc_user_config.h \
            file://0001-disable-Doxygen.patch \
            file://0002-fix-libevent-build-with-CMake-in-Yocto.patch"
 SRC_URI += "\
@@ -48,6 +49,7 @@ EXTRA_OECMAKE += " \
     -DDEVELOPER_MODE=${MBED_EDGE_CORE_CONFIG_DEVELOPER_MODE} \
     -DFACTORY_MODE=${MBED_EDGE_CORE_CONFIG_FACTORY_MODE} \
     -DBYOC_MODE=${MBED_EDGE_CORE_CONFIG_BYOC_MODE} \
+    -DCLOUD_CLIENT_CONFIG=${WORKDIR}/edge_gw_mcc_user_config.h \
     ${MBED_EDGE_CORE_CUSTOM_CMAKE_ARGUMENTS}"
 
 inherit cmake update-rc.d systemd


### PR DESCRIPTION
…lion Edge

Use this configuration to define the endpoint_type=EDGE_GW. This will
help classify the feature rich gateway as "Edge Gateways" vs feature free gateway
as "Gateway" in Pelion portal. Also reduced the MBED_CLOUD_CLIENT_LIFETIME to 10 minutes.
