### PR TITLE
Added 'warrior' as an additional compatible layer to meta-pelion-edge.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "meta-rpi"
 BBFILE_PATTERN_meta-rpi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpi = "16"
 
-LAYERSERIES_COMPAT_meta-rpi = "thud"
+LAYERSERIES_COMPAT_meta-rpi = "warrior thud"


### PR DESCRIPTION
### Problem: 
Local builds started failing yesterady with the following error:

`ERROR: Layer meta-rpi is not compatible with the core layer which only supports these series: warrior (layer is compatible with thud)`

### Note

~No CI builds appear to be affected _yet_, but I was unable to find one that has run successfully within the last couple of days.~ Nvm, seems that Yash already ran into problems.