### PR TITLE
Feature/peledge19 936

### DIFF
--- a/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_activate.sh
+++ b/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_activate.sh
@@ -19,12 +19,12 @@ VALUE=$(cp $HEADER /userdata/extended/header.bin)
 mkdir -p /userdata/.logs-before-upgrade
 cp -R /wigwag/log/* /userdata/.logs-before-upgrade/
 
-killall maestro
-/etc/init.d/maestro.sh start
+systemctl stop maestro
+systemctl start maestro
 
 mv $FIRMWARE /upgrades/firmware.tar.gz
 tar -xzf /upgrades/firmware.tar.gz -C /upgrades/
-/etc/init.d/deviceOS-watchdog start
+systemctl start deviceos-wd
 reboot
 echo "-------------------- Finished activate.sh -------------------------"
 exit $VALUE

--- a/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_activate.sh
+++ b/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_activate.sh
@@ -19,6 +19,9 @@ VALUE=$(cp $HEADER /userdata/extended/header.bin)
 mkdir -p /userdata/.logs-before-upgrade
 cp -R /wigwag/log/* /userdata/.logs-before-upgrade/
 
+# save version checksum
+md5sum /wigwag/etc/versions.json > /userdata/mbed/version_checksum.md5
+
 systemctl stop maestro
 systemctl start maestro
 

--- a/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_active_details.sh
+++ b/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_active_details.sh
@@ -11,10 +11,13 @@
 . /wigwag/mbed/arm_update_cmdline.sh
 # copy stored header to expected location
 echo "-------------------- Executing active_details.sh -------------------------"
-VALUE=$(cp /userdata/extended/header.bin $HEADER)
 
-echo $HEADER
-echo "-------------------- Finished active_details.sh -------------------------"
-
-exit $VALUE
-
+if md5sum -c /userdata/mbed/version_checksum.md5 | grep -q 'FAILED'; then
+  VALUE=$(cp /userdata/extended/header.bin $HEADER)
+  echo $HEADER
+  echo "-------------------- Build version changed, returning header --------------------";
+  exit $VALUE
+else
+  echo "-------------------- Build version same, returning null --------------------";
+  exit
+fi


### PR DESCRIPTION
Following changes are incorporated in this PR:
- PELEDGE19-934 Using systemd commands to start/stop processes
- PELEDGE19-936 Using md5 sum to validate build version mismatch for update campaign, this will be deciding factor to validate whether update was successfull or not