### PR TITLE
mbed-fcc fix

### DIFF
--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -25,6 +25,7 @@ do_configure () {
 	curl -k https://bootstrap.pypa.io/get-pip.py | python
 	export PYTHONPATH=`pwd`/recipe-sysroot-native/user/lib/python2.7
 	export PATH=$PYTHONPATH:$PATH
+	python -m pip install pip==19.3.1
 	python -m pip install mbed-cli click requests
 }
 


### PR DESCRIPTION
`pip` v20.x.x has been causing dependency issues this weeks.

This PR pins `pip` to the last major version after it's been installed.