### PR TITLE
Updated maestro SHA to test the memory leak fixes

### DIFF
--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -6,7 +6,7 @@ Restart=always
 RestartSec=5s
 Environment="LD_LIBRARY_PATH=/wigwag/system/lib"
 ExecStartPre=mkdir -p /userdata/etc/
-ExecStart=/wigwag/system/bin/maestro -config /wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
+ExecStart=env GODEBUG=madvdontneed=1 /wigwag/system/bin/maestro -config /wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
 
 [Install]
 RequiredBy=network.target

--- a/recipes-wigwag/maestro/maestro_0.0.1.bb
+++ b/recipes-wigwag/maestro/maestro_0.0.1.bb
@@ -39,7 +39,7 @@ file://maestro.service \
 "
 
 SRCREV_FORMAT="m"
-SRCREV_m="1b3b088edaea6a7e43535ec4d0e4d0ab6d6833aa"
+SRCREV_m="99c65304f218d3af452920fca1972df349e62395"
 
 GO_IMPORT = "github.com/armPelionEdge/maestro"
 


### PR DESCRIPTION
1. This SHA has fixes to the memory leak
2. Updated maestro.service to start the process with madvdontneed Go env flag.