### PR TITLE
Added pip install step to pin pip to an older version

### DIFF
--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -25,6 +25,7 @@ do_configure () {
 	curl -k https://bootstrap.pypa.io/get-pip.py | python
 	export PYTHONPATH=`pwd`/recipe-sysroot-native/user/lib/python2.7
 	export PATH=$PYTHONPATH:$PATH
+	python -m pip install pip==19.3.1
 	python -m pip install mbed-cli click requests
 }
 


### PR DESCRIPTION
mbed-fcc fails to install with latest pip version. Thus v1.0.0 of meta-pelion-edge is broken currently. This PR will fix the release.