### PR TITLE
Locking the click version fixes the 1.0.1 release of meta-pelion-edge

### DIFF
--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -26,7 +26,7 @@ do_configure () {
 	export PYTHONPATH=`pwd`/recipe-sysroot-native/user/lib/python2.7
 	export PATH=$PYTHONPATH:$PATH
 	python -m pip install pip==19.3.1
-	python -m pip install mbed-cli click requests
+	python -m pip install mbed-cli click==7.0 requests
 }
 
 do_compile() {


### PR DESCRIPTION
Recent update to click python module broke the mbed-fcc. Locked the click
version to 7.0. This fixes the bug - https://jira.arm.com/browse/PELEDGE19-2493