### PR TITLE
Enabling relay-term service

### DIFF
--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -167,6 +167,7 @@ WIGWAG_STUFF = " \
     deviceos-users \
     global-node-modules \
     wwrelay-utils \
+    relay-term \
 "
 
 OPENSSL_102 = " \

--- a/recipes-wigwag/relay-term/files/pelion-relay-term.service
+++ b/recipes-wigwag/relay-term/files/pelion-relay-term.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=relay terminal for remote terminals in pelion cloud
-After=maestro.service network-online.target
+After=maestro.service
 
 [Service]
 Restart=always
@@ -9,4 +9,4 @@ Environment=NODE_PATH=/wigwag/devicejs-core-modules/node_modules
 ExecStart=/usr/bin/node /wigwag/wigwag-core-modules/relay-term/src/index.js start /wigwag/wigwag-core-modules/relay-term/config/config.json
 
 [Install]
-WantedBy=network-online.target
+WantedBy=network.target


### PR DESCRIPTION
Adding relay term service on the gateway. This enables the remote terminal feature from Pelion cloud.