### PR TITLE
Work around segfault in Maestro

### DIFF
--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -5,6 +5,7 @@ Descritpion=Maestro: Network, Config, DeviceJS manager
 Restart=always
 RestartSec=5s
 Environment="LD_LIBRARY_PATH=/wigwag/system/lib"
+ExecStartPre=mkdir -p /userdata/etc/
 ExecStart=/wigwag/system/bin/maestro -config /wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
 
 [Install]


### PR DESCRIPTION
This avoids a race where devicejs (a process started by maestro)
creates the `/userdata/etc/` directory, that maestro requires
concurrently. Instead, I added a step before starting maestro
that creates this directory.