### PR TITLE
Use path unit to monitor the change in identity file to restart maestro

### DIFF
--- a/recipes-wigwag/maestro/maestro/maestro-watcher.path
+++ b/recipes-wigwag/maestro/maestro/maestro-watcher.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor the changes to identity.json file and restart maestro
+
+[Path]
+PathChanged=/userdata/edge_gw_config/identity.json
+Unit=maestro-watcher.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/maestro/maestro/maestro-watcher.service
+++ b/recipes-wigwag/maestro/maestro/maestro-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Maestro restarter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart maestro.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/maestro/maestro_0.0.1.bb
+++ b/recipes-wigwag/maestro/maestro_0.0.1.bb
@@ -36,6 +36,8 @@ FILES_${PN} += "\
 SRC_URI="git://git@github.com/armPelionEdge/maestro.git;protocol=ssh;branch=master;name=m \
 file://maestro.sh \
 file://maestro.service \
+file://maestro-watcher.service \
+file://maestro-watcher.path \
 "
 
 SRCREV_FORMAT="m"
@@ -116,4 +118,6 @@ do_install() {
   install -m 0755 -o deviceos -g deviceos ${B}/${GREASE_SRC}/deps/lib/libgrease.so ${D}/${WSL}
   install -m 0755 -o deviceos -g deviceos ${B}/${GREASE_SRC}/deps/lib/libgrease.so.1 ${D}/${WSL}
   install -m 0644 ${WORKDIR}/maestro.service ${D}${systemd_system_unitdir}/maestro.service
+  install -m 0644 ${WORKDIR}/maestro-watcher.service ${D}${systemd_system_unitdir}/maestro-watcher.service
+  install -m 0644 ${WORKDIR}/maestro-watcher.path ${D}${systemd_system_unitdir}/maestro-watcher.path
 }


### PR DESCRIPTION
With path units, you can monitor files and directories for events and use them to execute service units. Added path file to monitor identity.json and call service unit which will restart maestro service. Once the gateway has been claimed, maestro needs to be restarted to consume the new identity and create config files for other gateway services.