### PR TITLE
Re-enable watchdog and install debug version of the binary

### DIFF
--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -165,6 +165,7 @@ WIGWAG_STUFF = " \
     twlib \
     devicedb \
     maestro \
+    maestro-watchdog \
     deviceos-users \
     global-node-modules \
     wwrelay-utils \

--- a/recipes-wigwag/deviceOSWD/deviceoswd/deviceos-wd.service
+++ b/recipes-wigwag/deviceOSWD/deviceoswd/deviceos-wd.service
@@ -4,8 +4,7 @@ Description="Device OS watchdog reseting service"
 [Service]
 Restart=always
 ExecStartPre=-/usr/bin/pkill deviceOSWD
-ExecStart=/wigwag/system/bin/deviceOSWD -w 3000 -m 900 -s /var/deviceOSkeepalive
-ExecStartPost=sh -c "echo -e \"dog_stop\" | socat unix-sendto:/var/deviceOSkeepalive STDIO"
+ExecStart=/wigwag/system/bin/deviceOSWD -w 300 -m 90 -s /var/deviceOSkeepalive
 ExecStop=sh -c "echo -e stop | socat unix-sendto:/var/deviceOSkeepalive STDIO"
 
 [Install]

--- a/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
+++ b/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
@@ -60,6 +60,10 @@ do_compile() {
     cp deviceOSWD deviceOSWD_a10_tiny841
 
     make clean
+    make deviceOSWD-rpi-3bplus-debug
+    cp deviceOSWD deviceOSWD_rpi_3bplus_debug
+
+    make clean
     make deviceOSWD-rpi-3bplus
     cp deviceOSWD deviceOSWD_rpi_3bplus
 }
@@ -79,6 +83,7 @@ do_install() {
     install -m 755 ${S}/deviceOSWD_a10_relay ${WSYS}/bin/
     install -m 755 ${S}/deviceOSWD_dummy_debug ${WSYS}/bin/
     install -m 755 ${S}/deviceOSWD_a10_tiny841 ${WSYS}/bin/
+    install -m 755 ${S}/deviceOSWD_rpi_3bplus_debug ${WSYS}/bin/
     install -m 755 ${S}/../deviceOS-watchdog ${D}${INIT_D_DIR}/deviceOS-watchdog
     install -m 755 ${S}/../deviceos-wd.service ${D}${systemd_system_unitdir}/deviceos-wd.service
 


### PR DESCRIPTION
This fixes https://jira.arm.com/browse/PELEDGE19-935. 
1. We should not stop watchdog after starting it. 
2. Install debug version of deviceos-wd for debugging purposes.
3. Reduced the "wait before starting hardware watchdog" time from 3000 to 300 aka 5 mins
4. Reduced the "The max allowed keep alive" time from 900 to 90 aka 1.5 mins