### PR TITLE
Monitor device client certificate, on change restart relay-term

### DIFF
--- a/recipes-wigwag/relay-term/files/relay-term-watcher.path
+++ b/recipes-wigwag/relay-term/files/relay-term-watcher.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor the changes to identity.json file and restart relay-term
+
+[Path]
+PathChanged=/userdata/edge_gw_config/.ssl/client.cert.pem
+Unit=pelion-relay-term-watcher.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/relay-term/files/relay-term-watcher.service
+++ b/recipes-wigwag/relay-term/files/relay-term-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Relay-term restarter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart pelion-relay-term.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/relay-term/relay-term_0.0.1.bb
+++ b/recipes-wigwag/relay-term/relay-term_0.0.1.bb
@@ -6,8 +6,15 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 RT_SERVICE_FILE = "pelion-relay-term.service"
 PR = "r1"
 
+FILES_${PN} += "\
+    ${systemd_system_unitdir}/${PN}-watcher.service\
+    ${systemd_system_unitdir}/${PN}-watcher.path\
+    "
 
-SRC_URI = "file://${RT_SERVICE_FILE}"
+SRC_URI = "file://${RT_SERVICE_FILE} \
+file://${PN}-watcher.service \
+file://${PN}-watcher.path \
+"
 
 inherit pkgconfig systemd
 
@@ -23,6 +30,8 @@ RDEPENDS_${PN} += "bash"
 do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 755 ${WORKDIR}/${RT_SERVICE_FILE} ${D}${systemd_system_unitdir}/${RT_SERVICE_FILE}
+    install -m 755 ${WORKDIR}/${PN}-watcher.service ${D}${systemd_system_unitdir}/${PN}-watcher.service
+    install -m 755 ${WORKDIR}/${PN}-watcher.path ${D}${systemd_system_unitdir}/${PN}-watcher.path
 }
 
 


### PR DESCRIPTION
When identity.json is written, maestro will generate configuration file for
gateway services and also write device certificates to file. Monitor the
device certificate and restart relay-term if it changes.