### PR TITLE
Revert "Removed whitespaes from interfaces file"

### DIFF
--- a/recipes-core/init-ifupdown/files/interfaces
+++ b/recipes-core/init-ifupdown/files/interfaces
@@ -6,5 +6,5 @@ iface eth0 inet dhcp
 
 #auto wlan0
 iface wlan0 inet dhcp
-wireless_mode managed
-wpa-conf /etc/wpa_supplicant.conf
+        wireless_mode managed
+        wpa-conf /etc/wpa_supplicant.conf


### PR DESCRIPTION
Reverts armPelionEdge/meta-pelion-edge#121

The whitespace was the correct syntax. More info - https://www.cyberciti.biz/faq/setting-up-an-network-interfaces-file/