### PR TITLE
Adding gateway services' templates and maestro config for RPi3

### DIFF
--- a/recipes-wigwag/maestro/maestro-rpi3.bb
+++ b/recipes-wigwag/maestro/maestro-rpi3.bb
@@ -1,0 +1,22 @@
+require maestro_0.0.1.inc
+
+COMPATIBLE_MACHINE = "raspberrypi3"
+
+PROVIDES += " maestro "
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/maestro/rpi3:"
+SRC_URI += "file://maestro-config-rpi3bplus.yaml \
+            file://devicejs.template.conf \
+            file://devicedb.template.conf \
+            file://radioProfile.template.json \
+            file://relayTerm.template.json \
+            "
+
+do_install_append() {
+    # Maestro configuration management
+    install -m 0644 ${WORKDIR}/maestro-config-rpi3bplus.yaml ${D}/${RUN_CONFIG_DIR}/maestro-config.yaml
+    install -m 0644 ${WORKDIR}/devicejs.template.conf ${D}/${TEMPLATE_CONFIG_DIR}/devicejs.template.conf
+    install -m 0644 ${WORKDIR}/devicedb.template.conf ${D}/${TEMPLATE_CONFIG_DIR}/devicedb.template.conf
+    install -m 0644 ${WORKDIR}/relayTerm.template.json ${D}/${TEMPLATE_CONFIG_DIR}/relayTerm.template.json
+    install -m 0644 ${WORKDIR}/radioProfile.template.json ${D}/${TEMPLATE_CONFIG_DIR}/radioProfile.template.json
+}

--- a/recipes-wigwag/maestro/maestro-rpi3.bb
+++ b/recipes-wigwag/maestro/maestro-rpi3.bb
@@ -14,6 +14,8 @@ SRC_URI += "file://maestro-config-rpi3bplus.yaml \
 
 do_install_append() {
     # Maestro configuration management
+    install -d ${D}/${RUN_CONFIG_DIR}
+    install -d ${D}/${TEMPLATE_CONFIG_DIR}
     install -m 0644 ${WORKDIR}/maestro-config-rpi3bplus.yaml ${D}/${RUN_CONFIG_DIR}/maestro-config.yaml
     install -m 0644 ${WORKDIR}/devicejs.template.conf ${D}/${TEMPLATE_CONFIG_DIR}/devicejs.template.conf
     install -m 0644 ${WORKDIR}/devicedb.template.conf ${D}/${TEMPLATE_CONFIG_DIR}/devicedb.template.conf

--- a/recipes-wigwag/maestro/maestro/maestro.service
+++ b/recipes-wigwag/maestro/maestro/maestro.service
@@ -6,7 +6,7 @@ Restart=always
 RestartSec=5s
 Environment="LD_LIBRARY_PATH=/wigwag/system/lib"
 ExecStartPre=mkdir -p /userdata/etc/
-ExecStart=env GODEBUG=madvdontneed=1 /wigwag/system/bin/maestro -config /wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
+ExecStart=env GODEBUG=madvdontneed=1 /wigwag/system/bin/maestro -config /wigwag/etc/run/maestro-config.yaml
 
 [Install]
 RequiredBy=network.target

--- a/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicedb.template.conf
@@ -1,0 +1,228 @@
+# The db field specifies the directory where the database files reside on
+# disk. If it doesn't exist it will be created.
+# **REQUIRED**
+db: {{LOCAL_DATABASE_STORAGE_DIRECTORY}}
+
+# The port field specifies the port number on which to run the database server
+port: {{LOCAL_DEVICEDB_PORT}}
+
+# The sync session limit is the number of sync sessions that can happen
+# concurrently. Adjusting this field allows the database node to synchronize
+# with its peers more or less quickly. It is reccomended that this field be
+# half the number of cores on the machine where the devicedb node is running
+# **REQUIRED**
+syncSessionLimit: 2
+
+# The sync session period is the time in milliseconds that determines the rate
+# at which sync sessions are initiated with neighboring peers. Adjusting this
+# too high will result in unwanted amounts of network traffic and too low may
+# result in slow convergence rates for replicas that have not been in contact
+# for some time. A rate on the order of seconds is reccomended generally
+# **REQUIRED**
+syncSessionPeriod: 1000
+
+# This field adjusts the maximum number of objects that can be transferred in
+# one sync session. A higher number will result in faster convergence between
+# database replicas. This field must be positive and defaults to 1000
+syncExplorationPathLimit: 1000
+
+# In addition to background syncing, updates can also be forwarded directly
+# to neighbors when a connection is established in order to reduce the time
+# that replicas remain divergent. An update will immediately get forwarded
+# to the number of connected peers indicated by this number. If this value is
+# zero then the update is forwarded to ALL connected peers. In a small network
+# of nodes it may be better to set this to zero.
+# **REQUIRED**
+syncPushBroadcastLimit: 0
+
+# Garbage collection settings determine how often and to what degree tombstones,
+# that is markers of deletion, are removed permananetly from the database
+# replica. The default values are the minimum allowed settings for these
+# properties.
+
+# The garbage collection interval is the amount of time between garbage collection
+# sweeps in milliseconds. The lowest it can be set is every ten mintues as shown
+# below but could very well be set for once a day, or once a week without much
+# ill effect depending on the use case or how aggresively disk space needs to be
+# preserved
+gcInterval: 300000
+
+# The purge age defines the age past which tombstone will be purged from storage
+# Tombstones are markers of key deletion and need to be around long enough to
+# propogate through the network of database replicas and ensure a deletion happens
+# Setting this value too low may cause deletions that don't propogate to all replicas
+# if nodes are often disconnected for a long time. Setting it too high may mean
+# that more disk space is used than is needed keeping around old tombstones for
+# keys that will no longer be used. This field is also in milliseconds
+gcPurgeAge: 31536000000
+
+alerts:
+    forwardInterval: 60000
+
+# This field can be used to specify how this node handles time-series data.
+# These settings adjust how and when historical data is purged from the
+# history. If this field is not specified then default values are used.
+history:
+#    # When this flag is true items in the history are purged from the log
+#    # after they are successfully forwarded to the cloud. When set to false
+#    # items are only purged after. It defaults to false if not specified
+    purgeOnForward: true
+#    # This setting controls the amount of events that are left in the log
+#    # before purging the oldest logged events. It is set to 0 by default
+#    # which means old events will never be purged from the log
+    eventLimit: 500000
+#    # This setting controls the mimimum number of events that will be left
+#    # in the log after a purge is triggered. In this case, a log purge
+#    # is triggered when there are 1001 events stored in the history log
+#    # and the purge will delete all events until only the 500 most recent
+#    # events remain. If this value is greater than or equal to eventLimit
+#    # then it is ignored. This field defaults to 0 which means all events
+#    # will be purged from disk once the event limit is reached.
+    eventFloor: 400000
+#    # This field controls how many events are batched together for deletion
+#    # when purging a range of events from the log. If 10000 events need to
+#    # be purged and this field is set to 1000 then there will be 10 batches
+#    # applied to the underlying storage each contining 1000 delete operations.
+#    # It is a good idea to leave this value between 1000 and 10000. Too large
+#    # a number can cause large amounts of memory to be used. This field defaults
+#    # to 1 if left unspecified meaning events will not be batched and purges
+#    # of large ranges may take a very long time. If this value is negative
+#    # then it defaults to 1.
+    purgeBatchSize: 1000
+    forwardInterval: 60000
+    forwardThreshold: 50
+    forwardBatchSize: 50
+
+# The merkle depth adjusts how efficiently the sync process resolves
+# differences between database nodes. A rule of thumb is to set this as high
+# as memory constraints allow. Estimated memory overhead for a given depth is
+# calculated with the formula: M = 3*(2^(d + 4)). The following table gives a
+# quick reference to choose an appropriate depth.
+#
+# depth   |   memory overhead
+# 2       |   192         bytes  (0.1      KiB)
+# 4       |   768         bytes  (0.8      KiB)
+# 6       |   3072        bytes  (3.0      KiB)
+# 8       |   12288       bytes  (12       KiB)
+# 10      |   49152       bytes  (48       KiB)
+# 12      |   196608      bytes  (192      KiB) (0.2   MiB)
+# 14      |   786432      bytes  (768      KiB) (0.7   MiB)
+# 16      |   3145728     bytes  (3072     KiB) (3.0   MiB)
+# 18      |   12582912    bytes  (12288    KiB) (12    MiB)
+# 20      |   50331648    bytes  (49152    KiB) (48    MiB)
+# 22      |   201326592   bytes  (196608   KiB) (192   MiB) (0.2 GiB)
+# 24      |   805306368   bytes  (786432   KiB) (768   MiB) (0.8 GiB)
+# 26      |   3221225472  bytes  (3145728  KiB) (3072  MiB) (3   GiB)
+# 28      |   12884901888 bytes  (12582912 KiB) (12288 MiB) (12  GiB)
+#
+# A larger merkle depth also allows more concurrency when processing many
+# concurrent updates
+# **REQUIRED**
+merkleDepth: 4
+
+# The peer list specifies a list of other database nodes that are in the same
+# cluster as this node. This database node will contiually try to connect to
+# and sync with the nodes in this list. Alternatively peers can be added at
+# runtime if an authorized client requests that the node connect to another
+# node.
+# **REQUIRED**
+peers:
+# Uncomment these next lines if there are other peers in the cluster to connect
+# to and edit accordingly
+#    - id: WWRL000001
+#      host: 127.0.0.1
+#      port: 9191
+#    - id: WWRL000002
+#      host: 127.0.0.1
+#      port: 9292
+
+# These are the possible log levels in order from lowest to highest level.
+# Specifying a particular log level means you will see all messages at that
+# level and below. For example, if debug is specified, all log messages will
+# be seen. If no level is specified or if the log level specified is not valid
+# then the level defaults to the error level
+# critical
+# error
+# warning
+# notice
+# info
+# debug
+logLevel: warning
+
+# This field can be used to specify a devicedb cloud node to which to connect
+# If omitted then no cloud connection is established.
+cloud:
+    # noValidate is a flag specifying whether or not to validate the cloud
+    # node's TLS certificate chain. If omitted this field defaults to false
+    # Setting this field to true is not reccomended in production. It can
+    # be useful, however, when running against a test cloud where self-signed
+    # certificates are used.
+    noValidate: false
+    # The id field is used to verify the host name that the cloud server provides
+    # in its TLS certificate chain. If this field is omitted then the host field
+    # will be used as the expected host name in the cloud's certificate. If
+    # noValidate is true then no verification is performed either way so this
+    # effectively ignored. In this example, the TLS certificate uses a wildcard
+    # certificate so the server name provided in the certificate will not
+    # match the domain name of the host to which this node is connecting.
+    uri: wss://{{ARCH_GW_SERVICES_RESRC}}/devicedb/sync
+
+    # Starting in version 1.3.0 of devicedb a seperate host name, port, and certificate
+    # name can be specified for historical data forwarding. This is to allow decoupling
+    # between the devicedb cloud service and historical data processing by putting
+    # historical data logging and gathering sync into a standalone cloud service
+    #
+    # The historyID field is used to verify the host name that the cloud server provides
+    # in its TLS certificate chain. If this field is omitted then the historyHost field
+    # will be used as the expected host name in the cloud's certificate. If
+    # noValidate is true then no verification is performed either way so this
+    # effectively ignored. In this example, the TLS certificate uses a wildcard
+    # certificate so the server name provided in the certificate will not 
+    # match the domain name of the host to which this node is connecting.
+    # historyID: "*.wigwag.io"
+    # historyHost and historyPort may be ommitted. In this case historyHost and
+    # historyPort are set to the normal cloud host and port
+    historyURI: {{ARCH_GW_SERVICES_URL}}/relay-history/history
+    alertsURI: {{ARCH_GW_SERVICES_URL}}/relay-alerts/alerts
+
+# The TLS options specify file paths to PEM encoded SSL certificates and keys
+# All connections between database nodes use TLS to identify and authenticate
+# each other. A single certificate and key can be used if that certificate has
+# the server and client extended key usage options enabled. If seperate
+# certificates are used for the client and server certificates then the common
+# name on the clint and server certificate must match. The common name of the
+# certificate is used to identify this database node with other database nodes
+# The rootCA file is the root certificate chain that was used to generate these
+# certificates and is shared between nodes in a cluster. A database client does
+# not need to provide a client certificate when sending a request to a database
+# node but does need to verify the database node's server certificate against
+# the same root certificate chain.
+# **REQUIRED**
+tls:
+    # If using a single certificate for both client and server authentication
+    # then it is specified using the certificate and key options as shown below
+    # If using seperate client and server certificates then uncomment the options
+    # below for clientCertificate, clientKey, serverCertificate, and serverKey
+
+    # A PEM encoded certificate with the 'server' and 'client' extendedKeyUsage
+    # options set
+    # certificate: path/to/cert.pem
+
+    # A PEM encoded key corresponding to the specified certificate
+    # key: path/to/key.pem
+
+    # A PEM encoded 'client' type certificate
+    clientCertificate: {{SSL_CERTS_PATH}}/client.cert.pem
+
+    # A PEM encoded key corresponding to the specified client certificate
+    clientKey: {{SSL_CERTS_PATH}}/client.key.pem
+
+    # A PEM encoded 'server' type certificate
+    serverCertificate: {{SSL_CERTS_PATH}}/server.cert.pem
+
+    # A PEM encoded key corresponding to the specified server certificate
+    serverKey: {{SSL_CERTS_PATH}}/server.key.pem
+
+    # A PEM encoded certificate chain that can be used to verify the previous
+    # certificates
+    rootCA: {{SSL_CERTS_PATH}}/ca-chain.cert.pem

--- a/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
@@ -1,0 +1,32 @@
+{
+    "modulesDirectory": "/wigwag/etc/devicejs/modules",
+    "port": 8080,
+    "cloudAddress": "{{ARCH_GW_SERVICES_URL}}/devicejs/socket.io",
+    "databaseConfig": {
+        "uri": "https://127.0.0.1:{{LOCAL_DEVICEDB_PORT}}",
+        "https": {
+            "ca": [
+                "{{SSL_CERTS_PATH}}/ca.cert.pem",
+                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+            ]
+        }
+    },
+    "https": {
+        "server": {
+            "key": "{{SSL_CERTS_PATH}}/server.key.pem",
+            "cert": "{{SSL_CERTS_PATH}}/server.cert.pem",
+            "ca": [
+                "{{SSL_CERTS_PATH}}/ca.cert.pem",
+                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+            ]
+        },
+        "client": {
+            "key": "{{SSL_CERTS_PATH}}/client.key.pem",
+            "cert": "{{SSL_CERTS_PATH}}/client.cert.pem",
+            "ca": [
+                "{{SSL_CERTS_PATH}}/ca.cert.pem",
+                "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+            ]
+        }
+    }
+}

--- a/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
+++ b/recipes-wigwag/maestro/maestro/rpi3/maestro-config-rpi3bplus.yaml
@@ -1,0 +1,456 @@
+unixLogSocket: /tmp/grease.socket
+sysLogSocket: /dev/log
+linuxKernelLog: true
+httpUnixSocket: /tmp/maestroapi.sock
+configDBPath: /userdata/etc/maestroConfig.db
+clientId: "{{ARCH_SERIAL_NUMBER}}"
+watchdog:
+    path: "/wigwag/system/lib/rp100wd.so"
+    opt1: "/var/deviceOSkeepalive"
+    opt2: "30"
+network:
+    interfaces:
+        - if_name: eth0
+          clear_addresses: true
+          dhcpv4: true
+          # set the mac addresses for this interface also:
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+        - if_name: wlan0
+          clear_addresses: true
+          dhcpv4: true
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+processes:
+    reaper_interval: 1500
+platform_readers:
+  - platform: "fsonly"
+    params:
+      identityPath: "/userdata/edge_gw_config/identity.json"
+var_defs:
+   - key: "TMP_DIR"
+     value: "/tmp"
+   - key: "WIGWAG_NODE_PATH"
+     value: "/wigwag/devicejs-core-modules/node_modules"
+   - key: "WIGWAG_DIR"
+     value: "/wigwag"
+   - key: "NODE_EXEC"
+     value: "/usr/bin/node"
+   - key: "DEVICEJS_ROOT"
+     value: "/wigwag/devicejs-ng"
+   - key: "DEVJS_CORE_MODULES"
+     value: "/wigwag/devicejs-core-modules"
+   - key: "MAESTRO_RUNNER_DIR"
+     value: "/wigwag/devicejs-core-modules/maestroRunner"
+   - key: "SSL_CERTS_PATH"
+     value: "/userdata/edge_gw_config/.ssl"
+   - key: "LOCAL_DEVICEDB_PORT"
+     value: 9000
+   - key: "LOCAL_DATABASE_STORAGE_DIRECTORY"
+     value: "/userdata/etc/devicejs/db"
+   - key: "RELAY_VERSIONS_FILE"
+     value: "/wigwag/etc/versions.json"
+   - key: "FACTORY_VERSIONS_FILE"
+     value: "/mnt/.overlay/factory/wigwag/etc/versions.json"
+   - key: "USER_VERSIONS_FILE"
+     value: "/mnt/.overlay/user/slash/wigwag/etc/versions.json"
+   - key: "UPGRADE_VERSIONS_FILE"
+     value: "/mnt/.overlay/upgrade/wigwag/etc/versions.json"
+devicedb_conn_config:
+    devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
+    devicedb_prefix: "maestro.configs" #default prefix
+    devicedb_bucket: "lww" #default bucket
+    relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
+    ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name     
+mdns:
+  # disable: true
+  static_records:
+   - name: "WigWagRelay"
+     service: "_wwservices._tcp"  # normally something like https or ftp
+     # domain: "local"     # local is default
+     interfaces: "eth0"
+     not_interfaces: "Witap0"
+     port: 3131
+     text:
+      - "wwid={{ARCH_SERIAL_NUMBER}}"
+     hostname: "wigwaggateway"
+   - name: "WigWagRelay_{{ARCH_SERIAL_NUMBER}}"
+     service: "_wwservices._tcp"  # normally something like https or ftp
+     # domain: "local"     # local is default
+     interfaces: "eth0"
+     not_interfaces: "Witap0"
+     port: 3131
+     text:
+      - "wwid={{ARCH_SERIAL_NUMBER}}"
+     hostname: "{{ARCH_SERIAL_NUMBER}}"
+symphony:
+# symphony system management APIs
+    # defaults to 10:
+    disable_sys_stats: true
+    sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
+    sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
+    client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
+    client_key: "{{ARCH_CLIENT_KEY_PEM}}"
+    host: "{{ARCH_GW_SERVICES_RESRC}}"
+    url_logs: "{{ARCH_GW_SERVICES_URL}}/relay-logs/logs"
+    url_stats: "{{ARCH_GW_SERVICES_URL}}/relay-stats/stats_obj"
+    # port: "{{ARCH_RELAY_SERVICES_PORT}}"
+targets:
+   - file: "/wigwag/log/devicejs.log"
+     rotate:
+         max_files: 4
+         max_file_size: 10000000  # 10MB max file size
+         max_total_size: 42000000
+         rotate_on_start: true
+     delim: "\n"
+     format_time: "[%ld:%d] "
+     format_level: "<%s> "
+     format_tag: "{%s} "
+     format_origin: "(%s) "
+     filters:
+       - levels: warn
+         format_pre: "\u001B[33m"    # yellow
+         format_post: "\u001B[39m"
+       - levels: error
+         format_pre: "\u001B[31m"    # red
+         format_post: "\u001B[39m"
+   - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
+     format_time: "\"timestamp\":%ld%03d, "
+     format_level: "\"level\":\"%s\", "
+     format_tag: "\"tag\":\"%s\", "
+     format_origin: "\"origin\":\"%s\", "
+     format_pre_msg: "\"text\":\""
+     format_post: "\"},"
+     flag_json_escape_strings: true
+     filters:
+       - levels: warn
+         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+       - levels: error
+         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+static_file_generators:
+   - name: "devicejs"
+     template_file: "/wigwag/etc/template/devicejs.template.conf"
+     output_file: "/wigwag/etc/devicejs/devicejs.conf"
+   - name: "devicedb"
+     template_file: "/wigwag/etc/template/devicedb.template.conf"
+     output_file: "/wigwag/etc/devicejs/devicedb.yaml"
+   - name: "relayTerm"
+     template_file: "/wigwag/etc/template/relayTerm.template.json"
+     output_file: "/wigwag/wigwag-core-modules/relay-term/config/config.json"
+   - name: "radioProfile"
+     template_file: "/wigwag/etc/template/radioProfile.template.json"
+     output_file: "/wigwag/devicejs-core-modules/rsmi/radioProfile.config.json"
+   - name: "ca_pem"
+     template: "{{ARCH_CA_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/ca.cert.pem"
+   - name: "intermediate_pem"
+     template: "{{ARCH_INTERMEDIATE_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+   - name: "client_key"
+     template: "{{ARCH_CLIENT_KEY_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/client.key.pem"
+   - name: "client_cert"
+     template: "{{ARCH_CLIENT_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/client.cert.pem"
+   - name: "server_key"
+     template: "{{ARCH_SERVER_KEY_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/server.key.pem"
+   - name: "server_cert"
+     template: "{{ARCH_SERVER_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/server.cert.pem"
+   - name: "ca_chain"
+     template: "{{ARCH_CA_CHAIN_CERT_PEM}}"
+     output_file: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem"
+container_templates:
+   - name: "deviceJS_process"
+     immutable: true  # don't store in DB
+     depends_on:
+        - "devicejs"
+     cgroup:                 # will implement later
+        mem_limit: 10000000
+     die_on_parent_death: true
+     inherit_env: true
+     add_env:
+        - "LD_PRELOAD=/usr/lib/libcrypto.so.1.0.2"
+        - "DEVJS_ROOT={{DEVICEJS_ROOT}}"
+        - "DEVJS_CONFIG_FILE=/wigwag/etc/devicejs/devicejs.conf"
+        - "NODE_PATH={{WIGWAG_NODE_PATH}}"
+     exec_cmd: "{{NODE_EXEC}}"        # will use PATH if not absolute path (as per execvp())
+     send_composite_jobs_to_stdin: true
+     send_grease_origin_id: true
+     exec_pre_args:
+        - "--max-old-space-size=128"
+        - "--max-semi-space-size=1"
+        - "{{MAESTRO_RUNNER_DIR}}/index.js"
+     composite_config: >
+        {
+           "debug":true
+        }
+   - name: "ble_node_process"
+     immutable: true  # don't store in DB
+     depends_on:
+        - "devicejs"
+     cgroup:                 # will implement later
+        mem_limit: 10000000
+     die_on_parent_death: true
+     inherit_env: true
+     add_env:
+        - "LD_PRELOAD=/usr/lib/libcrypto.so.1.0.2"
+        - "DEVJS_ROOT={{DEVICEJS_ROOT}}"
+        - "DEVJS_CONFIG_FILE=/wigwag/etc/devicejs/devicejs.conf"
+        - "NODE_PATH={{WIGWAG_NODE_PATH}}"
+     exec_cmd: "{{NODE_EXEC}}"        # will use PATH if not absolute path (as per execvp())
+     send_composite_jobs_to_stdin: true
+     send_grease_origin_id: true
+     exec_pre_args:
+        - "--max-old-space-size=1024"
+        - "--max-semi-space-size=1"
+        - "{{MAESTRO_RUNNER_DIR}}/index.js"
+     composite_config: >
+        {
+           "debug":true
+        }
+   - name: "node_process"
+     die_on_parent_death: true
+     immutable: true  # don't store in DB
+     cgroup:                 # will implement later
+        mem_limit: 10000000
+     inherit_env: true
+     exec_cmd: "{{NODE_EXEC}}"        # will use PATH if not absolute path (as per execvp())
+     exec_pre_args:
+        - "--max-old-space-size=128"
+        - "--max-semi-space-size=1"
+jobs:
+   - job: "devicedb"
+     immutable: true
+     die_on_parent_death: true
+     exec_cmd: "/wigwag/system/bin/devicedb"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 1
+     exec_args:
+        - "start"
+        - "-conf=/wigwag/etc/devicejs/devicedb.yaml"
+   - job: "devicejs"
+     defer_running_status: 30000   # waits 8 seconds before marking this Job as RUNNING, which delays all dependencies
+     depends_on:
+        - "devicedb"
+     container_template: "node_process"
+     immutable: true
+     die_on_parent_death: true
+     env:
+        - "LD_PRELOAD=/usr/lib/libcrypto.so.1.0.2"
+        - "NODE_PATH={{DEVICEJS_ROOT}}/node_modules"
+        - "DEVJS_LOGGER={\"modulepath\":\"{{WIGWAG_NODE_PATH}}/grease-log-client\",\"type\":\"global\"}"
+     exec_cmd: "{{DEVICEJS_ROOT}}/src/runtime/start"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 10
+     exec_args:
+        - "--config=/wigwag/etc/devicejs/devicejs.conf"
+   - job: "MbedDeviceJSBridge"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../mbed/mbed-devicejs-bridge"
+     container_template: "deviceJS_process"
+     composite_id: "mbed"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+            "debug": true,
+            "mapUnplacedDevices": true,
+            "ignoreDevicesById" : [],
+            "relayID": "{{ARCH_SERIAL_NUMBER}}",
+            "mbedAPIKey": "ak_1MDE1ZDUwYTFmYmM2MDI0MjBhMDExMTA5MDAwMDAwMDA015e967fe74802420a01390300000000aJOhYRqzTXINzN9Aw2OkV5WrG0YwgmKS",
+            "spawnEdgeCore": false,
+            "edgeExecCmd": ["/apps/mbed-cloud-edge-confidential-w/build/mcc-linux-x86/existing/bin/edge-core","/tmp/edge.sock","9101"],
+            "ssl":{
+              "key":"{{SSL_CERTS_PATH}}/client.key.pem",
+              "cert":"{{SSL_CERTS_PATH}}/client.cert.pem"
+            }
+        }
+   - job: "core-interfaces"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../core-interfaces"
+     container_template: "deviceJS_process"
+     composite_id: "all-modules"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {}
+   - job: "RelayStatsSender"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../wigwag-core-modules/RelayStatsSender"
+     container_template: "deviceJS_process"
+     composite_id: "user"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "cloudAddress":"{{ARCH_GW_SERVICES_URL}}",
+          "relayID":"{{ARCH_SERIAL_NUMBER}}",
+          "ssl":{
+              "key":"{{SSL_CERTS_PATH}}/client.key.pem",
+              "cert":"{{SSL_CERTS_PATH}}/client.cert.pem",
+              "ca":[
+                  "{{SSL_CERTS_PATH}}/ca.cert.pem",
+                  "{{SSL_CERTS_PATH}}/intermediate.cert.pem"
+              ]
+          },
+          "versionsFile":"{{RELAY_VERSIONS_FILE}}",
+          "factoryVersionsFile": "{{FACTORY_VERSIONS_FILE}}",
+          "userVersionsFile": "{{USER_VERSIONS_FILE}}",
+          "upgradeVersionsFile": "{{UPGRADE_VERSIONS_FILE}}",
+          "relayInfo": {
+              "serialNumber": "{{ARCH_SERIAL_NUMBER}}",
+              "hardwareVersion": "{{ARCH_HARDWARE_VERSION}}",
+              "radioConfig": "{{ARCH_RADIO_CONFIG}}",
+              "ledConfig": "{{ARCH_LED_COLOR_PROFILE}}",
+              "cloud": "{{ARCH_GW_SERVICES_URL}}",
+              "ethernetMac": "{{ARCH_ETHERNET_MAC}}"
+          }
+        }
+   - job: "LEDController"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../wigwag-core-modules/LEDController"
+     container_template: "deviceJS_process"
+     composite_id: "core"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "ledBrightness": 255,
+          "heartbeatBrightness": 128,
+          "ledColorProfile":"{{ARCH_LED_COLOR_PROFILE}}",
+          "ledDriverSocketPath": "/var/deviceOSkeepalive"
+        }
+   - job: "VirtualDeviceDriver"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../wigwag-core-modules/VirtualDeviceDriver"
+     container_template: "deviceJS_process"
+     composite_id: "user"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "deviceControllersDirectory": "templates",
+          "hideTemplates": [ "VideoCamera" ],
+          "logLevel": 1
+        }
+   - job: "bluetoothlowenergy"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../bluetoothlowenergy"
+     container_template: "ble_node_process"
+     composite_id: "ble"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "hciDeviceID": 0,
+          "version": "1.0.2",
+          "logLevel": 5,
+          "activityLength": 100,
+          "platform":"",
+          "serialNumber": "{{ARCH_SERIAL_NUMBER}}"
+        }
+   - job: "zigbeeHA"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../zigbeeHA"
+     container_template: "deviceJS_process"
+     composite_id: "zigbee"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "siodev":"/dev/ttyUSB0",
+          "devType":0,
+          "newNwk":false,
+          "channelMask":25,
+          "baudRate":115200,
+          "log_level":1,
+          "networkRefreshDuration":17000,
+          "panIdSelection":"randomInRange",
+          "panId":23,
+          "platform":"",
+          "logLevel": 2 //Available- info- 2, debug- 3, trace- 4, error- 0, warn- 1
+        }
+   - job: "OnsiteEnterpriseServer"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../wigwag-core-modules/onsite-enterprise-server"
+     container_template: "deviceJS_process"
+     composite_id: "user"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "prodPort": "3131",
+          "modelDefinitions": "/api/models",
+          "logRequests": false,
+          "logLevel": 2
+        }
+   - job: "DevStateManager"
+     immutable: true  # don't store in DB
+     exec_cmd: "${thisdir}/../../wigwag-core-modules/DevStateManager"
+     container_template: "deviceJS_process"
+     composite_id: "core"
+     restart: true
+     restart_limit: 5000
+     restart_pause: 90
+     config: |
+        {
+          "logLevel": 1,
+          "pollingResolution": 500,
+          "defaultPollingRate": 51000,
+          "maxPollingCycles": 65535,
+          "pollingSchemes": {
+              "fast": {
+                  "interval": 21500,
+                  "interfaces": [
+                      "Facades/HasTemperature",
+                      "Facades/ThermostatGStatus",
+                      "Facades/ThermostatSupplyTemperature",
+                      "Facades/ThermostatReturnTemperature",
+                      "Facades/ThermostatW1Status",
+                      "Facades/ThermostatW2Status",
+                      "Facades/ThermostatY1Status",
+                      "Facades/ThermostatY2Status"
+                  ]
+              },
+              "medium": {
+                  "interval": 293500,
+                  "interfaces": [
+                      "Facades/ThermostatMode",
+                      "Facades/OccupiedCoolTemperatureLevel",
+                      "Facades/OccupiedHeatTemperatureLevel",
+                      "Facades/UnoccupiedCoolTemperatureLevel",
+                      "Facades/UnoccupiedHeatTemperatureLevel",
+                      "Facades/ThermostatFanMode",
+                      "Facades/OccupancyMode"
+                  ]
+              },
+              "slow": {
+                  "interval": 900000,
+                  "interfaces": [
+                  ]
+              },
+              "never": {
+                  "interval": 0,
+                  "interfaces": [
+                      "Facades/KeypadLockLevel",
+                      "Facades/TemperatureDisplayMode",
+                      "Facades/ThermostatDeadband",
+                      "Facades/Humidity",
+                      "Facades/HasMotion",
+                      "Facades/UnoccupiedAutoTemperatureLevel",
+                      "Facades/OccupiedAutoTemperatureLevel"
+                  ]
+              }
+          }
+        }
+config_end: true

--- a/recipes-wigwag/maestro/maestro/rpi3/radioProfile.template.json
+++ b/recipes-wigwag/maestro/maestro/rpi3/radioProfile.template.json
@@ -1,0 +1,578 @@
+{
+    "hardwareVersion": "{{ARCH_HARDWARE_VERSION}}",
+    "radioConfig": "{{ARCH_RADIO_CONFIG}}",
+    "pcb_map": {
+        "0.1.1": {
+            "M1": {
+                "description": "802.15.4 radio module is laid out orthogonal to the relay",
+                "siodev": "/dev/ttyS4",
+                "gpios": {
+                    "reset": 98,
+                    "data": 97,
+                    "clock": 96
+                }
+            },
+            "M2": {
+                "description": "Z-Wave module",
+                "siodev": "/dev/ttyS5",
+                "gpios": {
+                    "reset": 101
+                }
+            },
+            "M3": {
+                "description": "Not yet populated"
+            },
+            "M4": {
+                "description": "802.15.4 radio module is laid out at an angle to the pcb",
+                "siodev": "/dev/ttyS6",
+                "gpios": {
+                    "reset": 102,
+                    "data": 104,
+                    "clock": 103
+                }
+            },
+            "P1": {
+                "description": "USB next to ethernet port",
+                "siodevsubpath": "3-1/3-1:1.0"
+            },
+            "P2": {
+                "description": "USB next to power connector",
+                "siodevsubpath": "4-1/4-1:1.0"
+            },
+            "usb_hub_1": {
+                "description": "USB next to power connector",
+                "siodevsubpath": "3-1/3-1:1.0"
+            },
+            "usb_hub_2": {
+                "description": "USB next to power connector",
+                "siodevsubpath": "3-1/3-1:1.0"
+            },
+            "usb_hub_3": {
+                "description": "USB next to power connector",
+                "siodevsubpath": "3-1/3-1:1.0"
+            }
+        },
+        "r2002": {
+            "M1": {
+                "description": "Radio slot at the edge of the pcb",
+                "siodev": "/dev/ttyS6",
+                "gpios": {
+                    "reset": 104,
+                    "data": 103,
+                    "clock": 102
+                }
+            },
+            "M2": {
+                "description": "Radio slot in the middle of the pcb",
+                "siodev": "/dev/ttyS4",
+                "gpios": {
+                    "reset": 119,
+                    "data": 118,
+                    "clock": 105
+                }
+            },
+            "P1": {
+                "description": "RS485 top port",
+                "siodevsubpath": "5-1/5-1:1.0",
+                "gpios": {
+                    "reset": 37
+                }
+            },
+            "P2": {
+                "description": "RS485 bottom port",
+                "siodevsubpath": "4-1/4-1:1.0",
+                "gpios": {
+                    "reset": 39
+                }
+            },
+            "P3": {
+                "description": "USB on core board",
+                "siodev": "/dev/serial/by-path/platform-1c14400.usb-usb-0:1:1.0-port0"
+            }
+        },
+        "rpi3bplus": {
+            "P1": {
+                "description": "USB on core board, located at top right away from ethernet connector",
+                "siodev": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.3:1.0-port0"
+            },
+            "P2": {
+                "description": "USB on core board, located at bottom right away from ethernet connector",
+                "siodev": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1.0-port0"
+            },
+            "P3": {
+                "description": "USB on core board, located at bottom left next to ethernet connector",
+                "siodev": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.1.3:1.0-port0"
+            },
+            "P4": {
+                "description": "USB on core board, located at top left next to ethernet connector",
+                "siodev": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.1.2:1.0-port0"
+            }
+        }
+    },
+    "modules": {
+        "wigwag-devices": {
+            "ulike-nc880": {
+                "ICs": [
+                    "cc2530",
+                    "cc2591"
+                ],
+                "applications": "802.15.4",
+                "baudrate": 115200,
+                "version": "2.2",
+                "programmer": "bin/cc2530prog-arm",
+                "firmware": "bin/cc2530-91-slip-radioread-v2_2.hex",
+                "testprog": "bin/slipcomms-arm"
+            },
+            "wigwag-cc2530": {
+                "ICs": [
+                    "cc2530",
+                    "cc2592"
+                ],
+                "applications": "802.15.4",
+                "baudrate": 115200,
+                "version": "2.2",
+                "programmer": "bin/cc2530prog-arm",
+                "firmware": "bin/cc2530-92-slip-radioread-v2_2.hex",
+                "testprog": "bin/slipcomms-arm"
+            }
+        },
+        "zigbeeHA": {
+            "ulike-nc880": {
+                "ICs": [
+                    "cc2530",
+                    "cc2591"
+                ],
+                "applications": "802.15.4",
+                "baudrate": 115200,
+                "programmer": "bin/cc2530prog-arm",
+                "firmware": "bin/cc2530-91-znp-radioread-v1_1.hex",
+                "testprog": "bin/zigbeeHA-test.js"
+            },
+            "wigwag-cc2530": {
+                "ICs": [
+                    "cc2530",
+                    "cc2592"
+                ],
+                "applications": "802.15.4",
+                "baudrate": 115200,
+                "programmer": "bin/cc2530prog-arm",
+                "firmware": "bin/cc2530-92-znp-radioread-v1_1.hex",
+                "testprog": "bin/zigbeeHA-test.js"
+            },
+            "smartrf05-cc2530em": {
+                "ICs": [
+                    "cc2530em"
+                ],
+                "applications": "802.15.4",
+                "baudrate": 115200
+            }
+        },
+        "ww-zwave": {
+            "ZM5304": {
+                "ICs": [
+                    "ZM5304"
+                ],
+                "applications": "Z-Wave",
+                "baudrate": 115200,
+                "dataBits": 8,
+                "stopBits": 1
+            }
+        },
+        "ModbusRTU": {
+            "usb": {
+                "baudrate": 19200,
+                "dataBits": 8,
+                "stopBits": 1,
+                "parity": "none"
+            },
+            "rs485": {
+                "ICs": [
+                    "FT232RL",
+                    "ISO3082"
+                ],
+                "applications": "RS485",
+                "baudrate": 19200,
+                "dataBits": 8,
+                "stopBits": 1,
+                "parity": "none"
+            }
+        },
+        "BACnet": {
+            "usb": {
+                "baudrate": 76800,
+                "dataBits": 8,
+                "stopBits": 1,
+                "parity": "none"
+            },
+            "rs485": {
+                "ICs": [
+                    "FT232RL",
+                    "ISO3082"
+                ],
+                "applications": "RS485",
+                "baudrate": 76800,
+                "dataBits": 8,
+                "stopBits": 1,
+                "parity": "none"
+            }
+        },
+        "Enocean": {
+            "usb": {
+                "baudrate": 57600,
+                "dataBits": 8,
+                "stopBits": 1,
+                "parity": "none"
+            }
+        }
+    },
+    "configurations": {
+        "SOFT_GW": {
+            "00": {}
+        },
+        "delledge3000": {
+            "00": {}
+        },
+        "delledge5000": {
+            "00": {}
+        },
+        "rpi3bplus": {
+            "00": {},
+            "01": {
+                "zigbeeHA": [
+                    "P1",
+                    "smartrf05-cc2530em"
+                ]
+            },
+            "02": {
+                "ModbusRTU": [
+                    "P1",
+                    "usb"
+                ],
+                "BACnet": [
+                    "P2",
+                    "usb"
+                ]
+            }
+        },
+        "0.1.1": {
+            "00": {},
+            "01": {
+                "wigwag-devices": [
+                    "M1",
+                    "ulike-nc880"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "ulike-nc880"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "usb"
+                ],
+                "BACnet": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "02": {
+                "wigwag-devices": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "usb"
+                ],
+                "BACnet": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "03": {
+                "wigwag-devices": [
+                    "M1",
+                    "ulike-nc880"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "ulike-nc880"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "04": {
+                "wigwag-devices": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "05": {
+                "wigwag-devices": [
+                    "M1",
+                    "ulike-nc880"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "ulike-nc880"
+                ],
+                "BACnet": [
+                    "P1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "06": {
+                "wigwag-devices": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "wigwag-cc2530"
+                ],
+                "BACnet": [
+                    "P1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "P2",
+                    "usb"
+                ]
+            },
+            "07": {
+                "wigwag-devices": [
+                    "M1",
+                    "ulike-nc880"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "ulike-nc880"
+                ]
+            },
+            "08": {
+                "wigwag-devices": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "wigwag-cc2530"
+                ]
+            },
+            "09": {
+                "wigwag-devices": [
+                    "M1",
+                    "ulike-nc880"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "ulike-nc880"
+                ],
+                "ModbusRTU": [
+                    "usb_hub_1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "usb_hub_2",
+                    "usb"
+                ],
+                "BACnet": [
+                    "usb_hub_3",
+                    "usb"
+                ]
+            },
+            "0a": {
+                "wigwag-devices": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ww-zwave": [
+                    "M2",
+                    "ZM5304"
+                ],
+                "zigbeeHA": [
+                    "M4",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "usb_hub_1",
+                    "usb"
+                ],
+                "Enocean": [
+                    "usb_hub_2",
+                    "usb"
+                ],
+                "BACnet": [
+                    "usb_hub_3",
+                    "usb"
+                ]
+            }
+        },
+        "r2002": {
+            "00": {},
+            "10": {
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ]
+            },
+            "11": {
+                "BACnet": [
+                    "P1",
+                    "rs485"
+                ],
+                "ModbusRTU": [
+                    "P2",
+                    "rs485"
+                ]
+            },
+            "12": {
+                "zigbeeHA": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ]
+            },
+            "13": {
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ],
+                "ww-zwave": [
+                    "P3",
+                    "ZM5304"
+                ]
+            },
+            "14": {
+                "zigbeeHA": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ],
+                "ww-zwave": [
+                    "P3",
+                    "ZM5304"
+                ]
+            },
+            "15": {
+                "zigbeeHA": [
+                    "M1",
+                    "wigwag-cc2530"
+                ],
+                "wigwag-devices": [
+                    "M2",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ],
+                "ww-zwave": [
+                    "P3",
+                    "ZM5304"
+                ]
+            },
+            "16": {
+                "wigwag-devices": [
+                    "M2",
+                    "wigwag-cc2530"
+                ],
+                "ModbusRTU": [
+                    "P1",
+                    "rs485"
+                ],
+                "BACnet": [
+                    "P2",
+                    "rs485"
+                ]
+            }
+        }
+    }
+}

--- a/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
+++ b/recipes-wigwag/maestro/maestro/rpi3/relayTerm.template.json
@@ -1,0 +1,6 @@
+{
+	"cloud": "{{ARCH_GW_SERVICES_URL}}/relay-term",
+	"noValidate": true,
+	"certificate": "{{SSL_CERTS_PATH}}/client.cert.pem",
+	"key": "{{SSL_CERTS_PATH}}/client.key.pem"
+}

--- a/recipes-wigwag/maestro/maestro_0.0.1.inc
+++ b/recipes-wigwag/maestro/maestro_0.0.1.inc
@@ -118,8 +118,6 @@ do_install() {
   install -d ${D}/${WSB}
   install -d ${D}/${WSL}
   install -d ${D}/${INIT_D_DIR}
-  install -d ${D}/${RUN_CONFIG_DIR}
-  install -d ${D}/${TEMPLATE_CONFIG_DIR}
   install -d ${D}${systemd_system_unitdir}
   install -m 0755 ${WORKDIR}/maestro.sh ${D}${INIT_D_DIR}/maestro.sh
   install -m 0755 "${B}/${GO_BUILD_BINDIR}/maestro" "${D}/${WSB}"

--- a/recipes-wigwag/maestro/maestro_0.0.1.inc
+++ b/recipes-wigwag/maestro/maestro_0.0.1.inc
@@ -26,9 +26,15 @@ PKGV = "1.0+git${GITPKGV}"
 
 PR = "r0"
 
+RUN_CONFIG_DIR="wigwag/etc/run"
+TEMPLATE_CONFIG_DIR="wigwag/etc/template"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/maestro:"
 FILES_${PN} += "\
     /wigwag/system/bin/*\
     /wigwag/system/lib/*\
+    /${RUN_CONFIG_DIR}/*\
+    /${TEMPLATE_CONFIG_DIR}/*\
     ${INIT_D_DIR}/*\
     ${systemd_system_unitdir}/maestro.service\
     ${systemd_system_unitdir}/maestro-watcher.service\
@@ -112,6 +118,8 @@ do_install() {
   install -d ${D}/${WSB}
   install -d ${D}/${WSL}
   install -d ${D}/${INIT_D_DIR}
+  install -d ${D}/${RUN_CONFIG_DIR}
+  install -d ${D}/${TEMPLATE_CONFIG_DIR}
   install -d ${D}${systemd_system_unitdir}
   install -m 0755 ${WORKDIR}/maestro.sh ${D}${INIT_D_DIR}/maestro.sh
   install -m 0755 "${B}/${GO_BUILD_BINDIR}/maestro" "${D}/${WSB}"


### PR DESCRIPTION
As the services' configurations are platform dependent and maestro
is tasked to generate configuration for all gw services, thus relocating
the template files from edge-utils to meta-pe/maestro recipe.