### PR TITLE
Reverting to thud as with warrior, RPi is not booting

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "meta-rpi"
 BBFILE_PATTERN_meta-rpi := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rpi = "16"
 
-LAYERSERIES_COMPAT_meta-rpi = "warrior"
+LAYERSERIES_COMPAT_meta-rpi = "thud"


### PR DESCRIPTION
After testing the clean build without meta-mbl layers #128 and with yocto warrior, it
is observed that the RPi is not booting. When I tested the same with thud it seems to
be working. Internal ticket has been created to upgrade the yocto version to Dunfell in
the next release.