### PR TITLE
Fixed relay-term not restarting after identity.json change

### DIFF
--- a/recipes-wigwag/relay-term/files/relay-term-watcher.path
+++ b/recipes-wigwag/relay-term/files/relay-term-watcher.path
@@ -3,7 +3,7 @@ Description=Monitor the changes to identity.json file and restart relay-term
 
 [Path]
 PathChanged=/userdata/edge_gw_config/.ssl/client.cert.pem
-Unit=pelion-relay-term-watcher.service
+Unit=relay-term-watcher.service
 
 [Install]
 WantedBy=network.target


### PR DESCRIPTION
Unit file name was misspelled in the path unit file