### PR TITLE
Added firmware update docs

### DIFF
--- a/docs/firmware_update_workflow.md
+++ b/docs/firmware_update_workflow.md
@@ -1,0 +1,60 @@
+# Updating Pelion Edge Yocto image
+
+This section explains how to:
+
+- [Generate a firmware update package](#generate-a-firmware-update-package) you can push to a device through a firmware update campaign.
+- [Initiate a firmware update campaign](#initiate-a-firmware-update-campaign).
+
+## Generate a delta firmware update package
+
+Follow the instructions provided in the readme of [scripts-pelion-edge](https://github.com/armPelionEdge/scripts-pelion-edge/tree/master) to create a delta update package.
+
+## Initiate a firmware update campaign
+Device Management pushes your firmware update package to a defined set of devices, which unpack the firmware update package and apply the updates within it.
+You can initiate a firmware update campaign targeting any registered device from Device Management Portal.
+
+<span class="notes">**Note:** You can also initiate a firmware update campaign using the APIs, [as explained in the Pelion Device Management online documentation](https://www.pelion.com/docs/device-management/current/updating-firmware/update-api-tutorial.html).</span>
+
+**To initiate a firmware update campaign:**
+1. Upload the firmware update tar.gz package to Pelion Device Management:
+    1. Log in to Device Management Portal.
+    1. From the left navigation pane, select **Firmware Update** > **Images**.
+    1. Click the **+ Upload Image** button.
+    1. Follow the instructions on the screen to upload the tar.gz file.
+        After you upload the file, Device Management Portal displays a URL from which devices can download the tar.gz file.
+1. Create a firmware update manifest:
+   1. Use the manifest-tool utility to [create a manifest file](https://github.com/ARMmbed/manifest-tool#creating-manifests) for your firmware update tar.gz package:
+      ```bash
+      manifest-tool create -u <firmware.url> -p <firmware-update.tar.gz> -o manifest
+      ```
+
+      Where:
+
+      - `<firmware.url>` is the URL of the firmware update tar.gz package, as shown in Device Management Portal. Devices use this URL to download the firmware update image.
+      - `<firmware-update.tar.gz>` is the firmware update package tar.gz file. The manifest-tool utility calculates a hash from the firmware update tar.gz.
+      - Make sure `.manifest_tool.json` is in the current directory.
+      - Make sure `.update-certificates/` folder is in the current directory.
+1. Upload the firmware update manifest to Device Management:
+   1. From the left navigation pane, select **Firmware Update** > **Manifests**.
+   1. Click the **+ Upload Manifest** button.
+   1. Follow the instructions on the screen to upload the manifest file.
+1. Create a device filter to select a set of registered devices that should receive the firmware update package:
+   1. From the left navigation pane, select **Device directory** > **Devices**.
+   1. In the grey bar above the list of devices, click the arrow next to **Filters**.
+   1. Choose an attribute and operator, and give a value, such as **Device ID**.
+
+      - To combine multiple attributes in one filter, click **Add another**.
+      - To use a raw string instead, click **Advanced view**.
+
+   1. Click **Save**.
+      This opens the **Filter name** popup window.
+
+   1. Give your filter a name.
+   1. Click **Save filter**.
+1. Create the campaign:
+    1. From the left navigation pane, select **Firmware Update** > **Update campaigns**.
+    1. Click the **+ New Campaign** button.
+    1. Populate the **Name** and **Description** (optional) fields.
+    1. From the **Manifest** dropdown list, select the manifest file uploaded earlier.
+    1. From the **Filter** dropdown list, select the filter that targets the devices you need to update.
+    1. Click **Finish** to start the campaign.

--- a/docs/port_fimware_update.md
+++ b/docs/port_fimware_update.md
@@ -1,0 +1,59 @@
+# Porting the Device Management Update client to systems running Edge Core
+
+The update process in Linux is driven mainly by shell scripts that you can adapt to a new target. To know more about the purpose of the scripts and how to configure it for your system please read the instructions provided in [Linux update implementation](https://www.pelion.com/docs/device-management/current/porting/porting-the-device-management-update-client-to-linux-systems.html#linux-update-implementation) section of the *Porting devices* document.
+
+## Steps followed to integrate update with Pelion Edge
+
+**Note:** The details of the firmware update package and the process used to update the target filesystem is out of scope of this document.
+
+The [Pelion Edge Yocto image](https://github.com/armPelionEdge/meta-pelion-edge) for RPi 3B+ target has two parts:
+- The [C source code patch](https://github.com/armPelionEdge/meta-pelion-edge/blob/master/recipes-wigwag/mbed-edge-core/files/rpi3/0001-change-path-to-upgrade-scripts.patch) - Customizes the [`pal-linux/source` file](https://github.com/ARMmbed/mbed-cloud-client/blob/master/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_yocto_rpi.c) for Pelion Edge Yocto target. This source file executes the below shell scripts.
+- The [shell scripts](https://github.com/armPelionEdge/meta-pelion-edge/tree/master/recipes-wigwag/mbed-edge-core/files/rpi3).
+
+**Note:** The scripts are examples and are designed to work only with Pelion Edge Yocto image. Please modify the scripts as per your requirements.
+
+The scripts requires the image to support OverlayFS and following partitions -
+1. `factory` - It is a read-only, lower directory file system (fs) which contains the image burned at the factory.
+1. `upgrade` - It is a also read-only, lower directory fs, but it is overlayed on top of *factory* fs. By default, the directory is empty. It is used to save the files which are applied during the firmware update process.
+1. `user` - It is a read-write, upper directory fs and contains the files which are modified by the user.
+1. `boot` - A read-write partition that contains the boot loader.
+1. `userdata` - A read-write partition to store the Linux user space program data. Typically, the data stored in this partition is protected during the factory update process unless a factory reset is performed.
+
+In this example, the system uses following shell scripts to perform firmware update:
+- [arm_update_activate.sh](https://github.com/armPelionEdge/meta-pelion-edge/blob/master/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_activate.sh) - This script runs once the firmware image is downloaded by edge-core. Lets inspect the content of the script -
+    1. Typically, the firmware update process erases the user partition and copies the files to the upgrade partition. If you wish to protect the files during this process, please save it under userdata partition, as in a typical workflow it is protected.
+
+    Thus, the the header file which contains the metadata associated with the firmware image is copied to a directory under userdata. This header file is required by edge-core after the firmware update has been applied in order to verify if the update was successful or not.
+        ```
+        cp $HEADER /userdata/extended/header.bin
+        ```
+
+    1. Save the Pelion Edge service logs. They might be required for post update debugging.
+        ```
+        cp -R /wigwag/log/* /userdata/.logs-before-upgrade/
+        ```
+
+    1. Save the firmware image to a desired location on the fs.
+        ```
+        mv $FIRMWARE /upgrades/firmware.tar.gz
+        ```
+
+        In this setup, we unpack the firmware tarball into the user partition, under `/upgrades` folder and reboot the gateway. The update process will start upon detecting the required files.
+        ```
+        tar -xzf /upgrades/firmware.tar.gz -C /upgrades/
+        ```
+
+    1. Exit the script with appropiate error code. If the code is non-zero value then edge-core will notify Pelion Device Management that the update has failed.
+
+- [arm_update_active_details.sh](https://github.com/armPelionEdge/meta-pelion-edge/blob/master/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_active_details.sh) - Returns the version (and associated metadata) of the active (running) firmware.
+
+    1. Provide the same header file which was saved before the start of firmware update process.
+        ```
+        cp /userdata/extended/header.bin $HEADER
+        ```
+
+    1. Exit the script with appropiate error code. If the code is non-zero value then edge-core will notify Pelion Device Management that the update has failed.
+
+
+- [arm_update_cmdline.sh](https://github.com/armPelionEdge/meta-pelion-edge/blob/master/recipes-wigwag/mbed-edge-core/files/rpi3/arm_update_cmdline.sh) - This file is used to parse the command line parameters which are passed to the shell scripts when called by by the C source file specified in the `pal-linux/source` directory. In this case it's the [update source file for Yocto target](https://github.com/ARMmbed/mbed-cloud-client/blob/master/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_yocto_rpi.c).
+


### PR DESCRIPTION
1. firmware_update_workflow.md - provide steps on how to perform firmware
update on system running Pelion Edge Yocto image.
1. port_firmware_update.md - Guide to port the Device Management Update client to
systems running Edge Core.

@AnotherButler  FYI, I reused the "Initiate a firmware update campaign" section from https://github.com/ARMmbed/pelion-dm-edge-docs/pull/43