### PR TITLE
Yocto uses sed to substitute final ${OEROOT} values for all ##OEROOT## values.

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -8,15 +8,15 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-    ${OEROOT}/meta \
-    ${OEROOT}/meta-poky \
-    ${OEROOT}/meta-openembedded/meta-oe \
-    ${OEROOT}/meta-openembedded/meta-filesystems \
-    ${OEROOT}/meta-openembedded/meta-networking \
-    ${OEROOT}/meta-openembedded/meta-perl \
-    ${OEROOT}/meta-openembedded/meta-python \
-    ${OEROOT}/meta-raspberrypi \
-    ${OEROOT}/meta-security \
-    ${OEROOT}/meta-pelion-edge \
-    ${OEROOT}/meta-nodejs \
+    ##OEROOT##/meta \
+    ##OEROOT##/meta-poky \
+    ##OEROOT##/meta-openembedded/meta-oe \
+    ##OEROOT##/meta-openembedded/meta-filesystems \
+    ##OEROOT##/meta-openembedded/meta-networking \
+    ##OEROOT##/meta-openembedded/meta-perl \
+    ##OEROOT##/meta-openembedded/meta-python \
+    ##OEROOT##/meta-raspberrypi \
+    ##OEROOT##/meta-security \
+    ##OEROOT##/meta-pelion-edge \
+    ##OEROOT##/meta-nodejs \
 "


### PR DESCRIPTION
More information - https://www.yoctoproject.org/docs/3.1.1/ref-manual/ref-manual.html#structure-build-conf-bblayers.conf