### PR TITLE
adds edge-proxy service in preparation for kubelet and docker

### DIFF
--- a/recipes-core/images/console-image.bb
+++ b/recipes-core/images/console-image.bb
@@ -152,6 +152,7 @@ WIGWAG_STUFF = " \
     deviceoswd \
     emacs \
     fftw \
+    edge-proxy \
     imagemagick \
     lcms \
     virtual/mbed-edge-core \

--- a/recipes-core/netbase/netbase/hosts
+++ b/recipes-core/netbase/netbase/hosts
@@ -1,0 +1,9 @@
+127.0.0.1       localhost.localdomain           localhost
+127.0.0.1		gateways.local
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/recipes-core/netbase/netbase_%.bbappend
+++ b/recipes-core/netbase/netbase_%.bbappend
@@ -1,0 +1,2 @@
+#prepend to take precedence over poky/meta
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/recipes-wigwag/edge-proxy/edge-proxy_git.bb
+++ b/recipes-wigwag/edge-proxy/edge-proxy_git.bb
@@ -1,0 +1,49 @@
+DESCRIPTION = "Tunneling proxy for all FOG services"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+inherit go pkgconfig gitpkgv systemd
+
+PR = "r0"
+SRC_URI = "git://git@github.com/armPelionEdge/edge-proxy.git;protocol=ssh;name=ep;depth=1\
+           file://edge-proxy.service\
+           file://edge-proxy-watcher.service\
+           file://edge-proxy.path\
+           file://launch-edge-proxy.sh\
+           file://edge-proxy.conf.json\
+           "
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "edge-proxy.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+
+SRCREV_FORMAT = "ep"
+SRCREV_ep = "e0a7389ae4322ce8ceede6e2051d1832eb17cab4"
+GO_IMPORT = "github.com/armPelionEdge/edge-proxy"
+
+RDEPENDS_${PN} = "jq"
+
+wbindir = "/wigwag/system/bin"
+wetcdir = "/wigwag/etc"
+FILES_${PN} = "\
+	${wbindir}/edge-proxy\
+	${wbindir}/launch-edge-proxy.sh\
+	${wetcdir}/edge-proxy.conf.json\
+  ${systemd_system_unitdir}/edge-proxy.service\
+  ${systemd_system_unitdir}/edge-proxy-watcher.service\
+  ${systemd_system_unitdir}/edge-proxy.path\
+	"
+
+do_install () {
+  install -d ${D}${wbindir}
+  install -m 0755 ${B}/${GO_BUILD_BINDIR}/edge-proxy ${D}${wbindir}/
+  install -m 0755 ${WORKDIR}/launch-edge-proxy.sh ${D}${wbindir}/
+  install -d ${D}${wetcdir}
+  install -m 0755 ${WORKDIR}/edge-proxy.conf.json ${D}${wetcdir}/
+  install -d ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/edge-proxy.service ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/edge-proxy-watcher.service ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/edge-proxy.path ${D}${systemd_system_unitdir}
+}
+
+do_package_qa[noexec] = "1"

--- a/recipes-wigwag/edge-proxy/files/edge-proxy-watcher.service
+++ b/recipes-wigwag/edge-proxy/files/edge-proxy-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=edge-proxy restarter
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart edge-proxy.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/edge-proxy/files/edge-proxy.conf.json
+++ b/recipes-wigwag/edge-proxy/files/edge-proxy.conf.json
@@ -1,0 +1,3 @@
+{
+	"edge_proxy_uri_relative_path": "/edge-proxy/connect"
+}

--- a/recipes-wigwag/edge-proxy/files/edge-proxy.path
+++ b/recipes-wigwag/edge-proxy/files/edge-proxy.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor the changes to identity.json file and restart edge-proxy
+
+[Path]
+PathChanged=/userdata/edge_gw_config/identity.json
+Unit=edge-proxy-watcher.service
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/edge-proxy/files/edge-proxy.service
+++ b/recipes-wigwag/edge-proxy/files/edge-proxy.service
@@ -1,0 +1,12 @@
+[Unit]
+Descritpion=Tunneling Proxy for gateways
+Requires=wait-for-pelion-identity.service
+After=wait-for-pelion-identity.service
+
+[Service]
+Restart=always
+RestartSec=5
+ExecStart=/wigwag/system/bin/launch-edge-proxy.sh
+
+[Install]
+WantedBy=network.target

--- a/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
+++ b/recipes-wigwag/edge-proxy/files/launch-edge-proxy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2020, Arm Limited and affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress /userdata/edge_gw_config/identity.json)
+GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress /userdata/edge_gw_config/identity.json)
+EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /wigwag/etc/edge-proxy.conf.json)
+
+
+
+
+exec /wigwag/system/bin/edge-proxy \
+-proxy-uri=${EDGE_K8S_ADDRESS} \
+-proxy-listen=0.0.0.0:8080 \
+-tunnel-uri=ws://gateways.local$EDGE_PROXY_URI_RELATIVE_PATH \
+-cert-strategy=tpm \
+-cert-strategy-options=socket=/tmp/edge.sock \
+-cert-strategy-options=path=/1/pt \
+-cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
+-cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
+-forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}

--- a/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
+++ b/recipes-wigwag/maestro/maestro/rpi3/devicejs.template.conf
@@ -1,6 +1,6 @@
 {
     "modulesDirectory": "/wigwag/etc/devicejs/modules",
-    "port": 8080,
+    "port": 8081,
     "cloudAddress": "{{ARCH_GW_SERVICES_URL}}/devicejs/socket.io",
     "databaseConfig": {
         "uri": "https://127.0.0.1:{{LOCAL_DEVICEDB_PORT}}",


### PR DESCRIPTION
Adds edge-proxy to console-image
sets 127.0.0.1		gateways.local in /etc/init.d in preparation for kubelet tunneling
Compiles and installs edge-proxy & associated systemd units with separate launcher script
Modifies devicejs config to use port 8081 as 8080 is needed by edge-kubelet