### PR TITLE
Release 2.1.0-1 - Updated package source file protocol from ssh to https.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-# Pelion Edge 2.1.0 - September 2020
+## Pelion Edge 2.1.0 - September 2020
 
 The primary feature in this release is the addition of container orchestration:
 
@@ -13,7 +13,6 @@ The primary feature in this release is the addition of container orchestration:
 - [docker] Adds Docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698). Docker's default storage location is moved to [/userdata/Docker](xxxx) to take advantage of /userdata's single (non-overlay) ext4 partition, enabling Docker to use the more performant overfs2.
 - [cni] Adds container networking interfaces [cni](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8d44f3bb16ba9ff316e2e3622366d386) to enable container network communication.
 
-
 ### Bug fixes
 
 - General syntax and whitespace changes in bitbake recipes.
@@ -24,13 +23,13 @@ The primary feature in this release is the addition of container orchestration:
 - When conducting back-to-back production factory flow with the Pelion Edge Provisioner, the mcc_config directory sometimes is not written correctly and upon reboot, Edge-Core does not connect properly. Workaround: Run the provisioner again.
 - After production factory flow, if you run the info command before Edge core pairs with the cloud, the info command shows N/A for the deviceID while displaying connected. Workaround: Delete the file /wigwag/system/lib/bash/relaystatics.sh, and rerun the info command.
 - Portal is not correctly updated after a firmware campaign in some instances.
+
+### Limitations
+
 - The maximum translated devices behind the edge gateway is 100.
+- Devices behind Pelion Edge do not support [auto-observation.](https://www.pelion.com/docs/device-management/current/connecting/device-guidelines.html#auto-observation)
+- Pelion Device Management Client enabled devices must first boostrap to the Pelion Device Management Cloud before connecting to Pelion Edge.
 - No moving devices are supported. (Device would be moving from Edge to another Edge device.)
-- Assumption is that no development is needed in device multiplexing code in Connect.
-- Device Echo is not supported. (Automatic grouping is not supported.)
-- No end-to-end security to translated device. Trust is between Edge and Pelion Device Management.
-- No bootstrapping for translated devices.
-- Registration on observation is not supported.
 
 ### Important note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 # Changelog
+# Pelion Edge 2.1.0 - September 2020
+
+The primary feature in this release is the addition of container orchestration:
+
+- [compiler] Switches to [golang 1.14.4](https://github.com/armPelionEdge/meta-pelion-edge/pull/158) compiler from 1.11.1. This includes poky meta upstream [go*.bbclass](classes/) files.
+- [edge-proxy] Adds [edge-proxy](https://github.com/armPelionEdge/edge-proxy) tunneling daemon to the [build](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-cf2bb0a8acf52dfc5336946e4e85d00a)and subsequent systemD unit and supporting [files](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-d168093479202d5365837188cd0ab52f).
+- [devicejs] Moves devicejs default port from [8080 to 8081](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-91df9bdf1d7512379b7145418e22a5a2) in support of edge-proxy using 8080 for kubelet.
+- [os] Modifies [/etc/hosts](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-2b56f81a8769186caec20129e7038331) creation file to support kubelet communication with edge-proxy using the address gateways.local.
+- [os] Adds poky's [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/) layer [bblayers](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8eb2e96d599896eef2db53b566b4d701)to bring in Docker and containered programs, as well as kernel optimizations specified in meta-virtualization to [local.conf](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-f427c8a66b8134441c4facaa0aeaa518)).
+- [os] Adds [boot flags](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a00df6690f4fb299ba7bae881b745122) to enable cgroups control over memory and CPU use.
+- [kubelet] Adds [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files), modified to enable container orchestration with Pelion cloud to the main [console-image](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-9ed858c519118697208a2af7585cf7ef).
+- [docker] Adds Docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698). Docker's default storage location is moved to [/userdata/Docker](xxxx) to take advantage of /userdata's single (non-overlay) ext4 partition, enabling Docker to use the more performant overfs2.
+- [cni] Adds container networking interfaces [cni](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8d44f3bb16ba9ff316e2e3622366d386) to enable container network communication.
+
+### Bug fixes
+- General syntax and whitespace changes in bitbake recipes.
+- Fixed the situation where the root password changes after an upgrade by changing the default WIPETHEUSER_PARTITION to 0.
+
+### Known issues
+- When conducting back-to-back production factory flow with the Pelion Edge Provisioner, the mcc_config directory sometimes is not written correctly and upon reboot, Edge-Core does not connect properly. Workaround: Run the provisioner again.
+- After production factory flow, if you run the info command before Edge core pairs with the cloud, the info command shows N/A for the deviceID while displaying connected. Workaround: Delete the file /wigwag/system/lib/bash/relaystatics.sh, and rerun the info command.
+- Portal is not correctly updated after a firmware campaign in some instances.
+- The maximum translated devices behind the edge gateway is 100.
+- No moving devices are supported. (Device would be moving from Edge to another Edge device.)
+- Assumption is that no development is needed in device multiplexing code in Connect.
+- Device Echo is not supported. (Automatic grouping is not supported.)
+- No end-to-end security to translated device. Trust is between Edge and Pelion Device Management.
+- No bootstrapping for translated devices.
+- Registration on observation is not supported.
+
+### Important note
+While provisioning your gateway, please use `vendor-id=42fa7b48-1a65-43aa-890f-8c704daade54` to unlock the rich node features, such as gateway logs and gateway terminal in the Pelion web portal.
+
+
 ## Release 2.1.0 - August 2020
 ### Added
 Primary feature in this release is the addition of container orchistration
@@ -9,7 +43,7 @@ Primary feature in this release is the addition of container orchistration
 * [os] adds poky's [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/) layer [bblayers](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8eb2e96d599896eef2db53b566b4d701)to bring in docker and containerd programs, as well as kernel optimizations specified in meta-virtualzation to [local.conf](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-f427c8a66b8134441c4facaa0aeaa518)).
 * [os] adds [boot flags](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a00df6690f4fb299ba7bae881b745122) to enable cgroups control over  memory and cpu utilization. 
 * [kubelet] Added [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files), modified to enable container orchistration with Pelion cloud to the main [console-image](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-9ed858c519118697208a2af7585cf7ef)
-* [docker] adds docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698).  Docker's default storage location is moved to [/userdata/Docker](xxxx) to take advantage of /userdata's single (non-overlay) ext4 partition, enabling docker to use the more perforamnt overfs2.
+* [docker] adds docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698).  Docker's default storage location is moved to /userdata/Docker to take advantage of /userdata's single (non-overlay) ext4 partition, enabling docker to use the more perforamnt overfs2.
 * [cni] adds contianer networking interfaces [cni](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8d44f3bb16ba9ff316e2e3622366d386) to enable container network communication
 ### Bug Fixes
 * general syntax and whitespace changes in bitbake reciepes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## Pelion Edge 2.1.0-1 - October 2020
+
+Updated package source file protocol from SSH to HTTPS.
+
 ## Pelion Edge 2.1.0 - September 2020
 
 The primary feature in this release is the addition of container orchestration:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 The primary feature in this release is the addition of container orchestration:
 
-- [compiler] Switches to [golang 1.14.4](https://github.com/armPelionEdge/meta-pelion-edge/pull/158) compiler from 1.11.1. This includes poky meta upstream [go*.bbclass](classes/) files.
+- [compiler] Switches to [golang 1.14.4](https://github.com/armPelionEdge/meta-pelion-edge/pull/158) compiler from 1.11.1. This includes poky meta upstream [go.bbclass](classes/) files.
 - [edge-proxy] Adds [edge-proxy](https://github.com/armPelionEdge/edge-proxy) tunneling daemon to the [build](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-cf2bb0a8acf52dfc5336946e4e85d00a)and subsequent systemD unit and supporting [files](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-d168093479202d5365837188cd0ab52f).
 - [devicejs] Moves devicejs default port from [8080 to 8081](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-91df9bdf1d7512379b7145418e22a5a2) in support of edge-proxy using 8080 for kubelet.
 - [os] Modifies [/etc/hosts](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-2b56f81a8769186caec20129e7038331) creation file to support kubelet communication with edge-proxy using the address gateways.local.
@@ -13,11 +13,14 @@ The primary feature in this release is the addition of container orchestration:
 - [docker] Adds Docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698). Docker's default storage location is moved to [/userdata/Docker](xxxx) to take advantage of /userdata's single (non-overlay) ext4 partition, enabling Docker to use the more performant overfs2.
 - [cni] Adds container networking interfaces [cni](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8d44f3bb16ba9ff316e2e3622366d386) to enable container network communication.
 
+
 ### Bug fixes
+
 - General syntax and whitespace changes in bitbake recipes.
 - Fixed the situation where the root password changes after an upgrade by changing the default WIPETHEUSER_PARTITION to 0.
 
 ### Known issues
+
 - When conducting back-to-back production factory flow with the Pelion Edge Provisioner, the mcc_config directory sometimes is not written correctly and upon reboot, Edge-Core does not connect properly. Workaround: Run the provisioner again.
 - After production factory flow, if you run the info command before Edge core pairs with the cloud, the info command shows N/A for the deviceID while displaying connected. Workaround: Delete the file /wigwag/system/lib/bash/relaystatics.sh, and rerun the info command.
 - Portal is not correctly updated after a firmware campaign in some instances.
@@ -30,26 +33,9 @@ The primary feature in this release is the addition of container orchestration:
 - Registration on observation is not supported.
 
 ### Important note
+
 While provisioning your gateway, please use `vendor-id=42fa7b48-1a65-43aa-890f-8c704daade54` to unlock the rich node features, such as gateway logs and gateway terminal in the Pelion web portal.
 
-
-## Release 2.1.0 - August 2020
-### Added
-Primary feature in this release is the addition of container orchistration
-* [compiler] Switched to [golang 1.14.4](https://github.com/armPelionEdge/meta-pelion-edge/pull/158) compiler from 1.11.1.  This includes poky meta upstream [go*.bbclass](classes/) files.
-* [edge-proxy] Added [edge-proxy](https://github.com/armPelionEdge/edge-proxy) tunneling daemon to the [build](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-cf2bb0a8acf52dfc5336946e4e85d00a)and subsequent systemD unit and supporting [files](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-d168093479202d5365837188cd0ab52f)
-* [devicejs] Moved devicejs default port from [8080 to 8081](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-91df9bdf1d7512379b7145418e22a5a2) in support of edge-proxy using 8080 for kubelet
-* [os] modified [/etc/hosts](https://github.com/armPelionEdge/meta-pelion-edge/pull/160/files#diff-2b56f81a8769186caec20129e7038331) creation file to support kubelet communication with edge-proxy using the address gateways.local
-* [os] adds poky's [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/) layer [bblayers](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8eb2e96d599896eef2db53b566b4d701)to bring in docker and containerd programs, as well as kernel optimizations specified in meta-virtualzation to [local.conf](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-f427c8a66b8134441c4facaa0aeaa518)).
-* [os] adds [boot flags](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a00df6690f4fb299ba7bae881b745122) to enable cgroups control over  memory and cpu utilization. 
-* [kubelet] Added [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files), modified to enable container orchistration with Pelion cloud to the main [console-image](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-9ed858c519118697208a2af7585cf7ef)
-* [docker] adds docker via rdepends in [edge-kubelet](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-a60a51806a69d10af75c2d0a4c752698).  Docker's default storage location is moved to /userdata/Docker to take advantage of /userdata's single (non-overlay) ext4 partition, enabling docker to use the more perforamnt overfs2.
-* [cni] adds contianer networking interfaces [cni](https://github.com/armPelionEdge/meta-pelion-edge/pull/161/files#diff-8d44f3bb16ba9ff316e2e3622366d386) to enable container network communication
-### Bug Fixes
-* general syntax and whitespace changes in bitbake reciepes
-* Fixed the situation where the root password changes after an upgrade by changing the default WIPETHEUSER_PARTITION to 0
-### Known issues
-* While provisioning your gateway, please use `vendor-id=42fa7b48-1a65-43aa-890f-8c704daade54` to unlock the rich node features, such as gateway logs and gateway terminal in the Pelion web portal.
 ## Release 2.0.0 - 2020-05-18
 ### Added
 * [mbed-edge] Upgraded mbed-edge, also known as edge-core, from 0.8.0 to 0.12.0.

--- a/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
+++ b/recipes-wigwag/deviceOSWD/deviceoswd_0.0.2.bb
@@ -16,7 +16,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r5"
 
 SRCREV = "0415f0887e050c1b1d78b2cdd73692f607e5e0af"
-SRC_URI = "git://git@github.com/armPelionEdge/edgeos-wd.git;protocol=ssh; \
+SRC_URI = "git://git@github.com/armPelionEdge/edgeos-wd.git;protocol=https; \
 file://deviceOS-watchdog \
 file://deviceos-wd.service \
 "

--- a/recipes-wigwag/devicedb/devicedb_0.0.12.bb
+++ b/recipes-wigwag/devicedb/devicedb_0.0.12.bb
@@ -7,7 +7,7 @@ GO_LINKSHARED=""
 inherit go pkgconfig gitpkgv
 
 PR = "r5"
-SRC_URI = "git://git@github.com/armPelionEdge/devicedb.git;protocol=ssh;name=ddb \
+SRC_URI = "git://git@github.com/armPelionEdge/devicedb.git;protocol=https;name=ddb \
 file://devicedb \
 "
 

--- a/recipes-wigwag/devicejs/devicejs_0.0.12.bb
+++ b/recipes-wigwag/devicejs/devicejs_0.0.12.bb
@@ -6,9 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 inherit pkgconfig gitpkgv npm-base npm-install
 
 PR = "r4"
-SRC_URI = "git://git@github.com/armPelionEdge/devicejs-ng.git;protocol=ssh;"
+SRC_URI = "git://git@github.com/armPelionEdge/devicejs-ng.git;protocol=https;"
 
-SRCREV = "5aa4eabdfac119a1f837c5ff2589d8104bc66997"
+SRCREV = "66b1a09507ac2a2a5d1f802081d45933ad8991cc"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/edge-proxy/edge-proxy_git.bb
+++ b/recipes-wigwag/edge-proxy/edge-proxy_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=86d3f3a95c324c9479bd8986
 inherit go pkgconfig gitpkgv systemd
 
 PR = "r0"
-SRC_URI = "git://git@github.com/armPelionEdge/edge-proxy.git;protocol=ssh;name=ep;depth=1 \
+SRC_URI = "git://git@github.com/armPelionEdge/edge-proxy.git;protocol=https;name=ep;depth=1 \
            file://edge-proxy.service \
            file://edge-proxy-watcher.service \
            file://edge-proxy.path \

--- a/recipes-wigwag/global-node-modules/global-node-modules_0.0.1.bb
+++ b/recipes-wigwag/global-node-modules/global-node-modules_0.0.1.bb
@@ -8,8 +8,8 @@ PV = "1.0+git${SRCPV}"
 PKGV = "1.0+git${GITPKGV}"
 PR = "r6"
 
-SRC_URI="git://git@github.com/armPelionEdge/edge-node-modules.git;protocol=ssh"
-SRCREV = "122835410976f23b6694d925d993e72c50ced053"
+SRC_URI="git://git@github.com/armPelionEdge/edge-node-modules.git;protocol=https"
+SRCREV = "274f7bffe63af30fee6e765485bbd40a0a8456be"
 SRCREV_devjs_prod_tools = "9f795d20bc68b0a49f4e1b004429aed6ba073a4b"
 
 S = "${WORKDIR}/git"
@@ -42,13 +42,13 @@ do_configure() {
 		oe_runnpm_native install -g node-gyp@5.1.1
 	fi
 
-	echo -en "{\n\"devjs-configurator\": \"http://github.com/armPelionEdge/devjs-configurator#master\"\n}\n" > ${WORKDIR}/overrides.json
+	echo -en "{\n\"devjs-configurator\": \"https://github.com/armPelionEdge/devjs-configurator#master\"\n}\n" > ${WORKDIR}/overrides.json
 
 	#--------------------devjs-production-tools-----------------------------------------------------------
 	cd ${S}/../
 	if [[ ! -e devjs-production-tools ]]; then
 		echo "devjs-production-tools does not exist" >> /tmp/global-node-modules.log
-		git clone git@github.com:armPelionEdge/devjs-production-tools.git
+		git clone https://github.com/armPelionEdge/devjs-production-tools.git
 		git -C devjs-production-tools checkout ${SRCREV_devjs_prod_tools}
 	else
 		echo "devjs-production-tools exists, lets pull" >>/tmp/global-node-modules.log

--- a/recipes-wigwag/isc-dhclient/isc-dhclient_1.0.bb
+++ b/recipes-wigwag/isc-dhclient/isc-dhclient_1.0.bb
@@ -13,7 +13,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "b5aa812b2ebaf6c866f6c24fb176d71b1e6e28ba"
-SRC_URI="git://git@github.com/armPelionEdge/node-isc-dhclient.git;protocol=ssh"
+SRC_URI="git://git@github.com/armPelionEdge/node-isc-dhclient.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/maestro-shell/maestro-shell_0.0.1.bb
+++ b/recipes-wigwag/maestro-shell/maestro-shell_0.0.1.bb
@@ -12,7 +12,7 @@ SRCREV = "e06b5e28d6beb46577710331168a84687bb4b370"
 
 PR = "r0"
 
-SRC_URI="git://git@github.com/armPelionEdge/maestro-shell.git;protocol=ssh;"
+SRC_URI="git://git@github.com/armPelionEdge/maestro-shell.git;protocol=https;"
 S= "${WORKDIR}/git"
 GO_IMPORT = "github.com/armPelionEdge/maestro-shell"
 

--- a/recipes-wigwag/maestro-watchdog/maestro-watchdog_0.0.1.bb
+++ b/recipes-wigwag/maestro-watchdog/maestro-watchdog_0.0.1.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 SRCREV = "54ee3bd50b063425606ad76aefad4167780d8760"
 
 PR = "r0"
-SRC_URI="git://git@github.com/armPelionEdge/rallypointwatchdogs.git;protocol=ssh;"
+SRC_URI="git://git@github.com/armPelionEdge/rallypointwatchdogs.git;protocol=https;"
 GO_IMPORT = "github.com/armPelionEdge/rallypointwatchdogs"
 
 do_compile() {

--- a/recipes-wigwag/maestro/maestro_0.0.1.inc
+++ b/recipes-wigwag/maestro/maestro_0.0.1.inc
@@ -44,7 +44,7 @@ FILES_${PN} += "\
     ${systemd_system_unitdir}/maestro-watcher.path\
     "
 
-SRC_URI="git://git@github.com/armPelionEdge/maestro.git;protocol=ssh;;name=m \
+SRC_URI="git://git@github.com/armPelionEdge/maestro.git;protocol=https;;name=m \
 file://maestro.sh \
 file://maestro.service \
 file://maestro-watcher.service \

--- a/recipes-wigwag/mbed-devicejs-bridge/mbed-devicejs-bridge_0.0.1.bb
+++ b/recipes-wigwag/mbed-devicejs-bridge/mbed-devicejs-bridge_0.0.1.bb
@@ -7,12 +7,12 @@ inherit autotools pkgconfig gitpkgv npm-base npm-install
 PV = "1.0+git${SRCPV}"
 PKGV = "1.0+git${GITPKGV}"
 SRCREV = "b9cb430e57cf4660d585c23db0e82756a567c652"
-SRC_URI = "git://git@github.com/armPelionEdge/mbed-devicejs-bridge;protocol=ssh;"
+SRC_URI = "git://git@github.com/armPelionEdge/mbed-devicejs-bridge;protocol=https;"
 PR = "r2"
 
 
-SRC_URI="git://git@github.com/armPelionEdge/mbed-devicejs-bridge;protocol=ssh;;name=bridge;destsuffix=git/bridge \
-git://git@github.com/armPelionEdge/mbed-edge-websocket.git;protocol=ssh;;name=edgejs;destsuffix=git/edgejs \
+SRC_URI="git://git@github.com/armPelionEdge/mbed-devicejs-bridge;protocol=https;;name=bridge;destsuffix=git/bridge \
+git://git@github.com/armPelionEdge/mbed-edge-websocket.git;protocol=https;;name=edgejs;destsuffix=git/edgejs \
 file://config-dev.json"
 SRCREV_FORMAT = "bridge-edgejs"
 SRCREV_bridge = "b9cb430e57cf4660d585c23db0e82756a567c652"

--- a/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
+++ b/recipes-wigwag/mbed-edge-core/mbed-edge-core.inc
@@ -12,7 +12,7 @@ MBED_EDGE_CORE_CONFIG_BYOC_MODE ?= "OFF"
 # Patches for quilt goes to files directory
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://git@github.com/ARMmbed/mbed-edge.git;protocol=ssh; \
+SRC_URI = "git://git@github.com/ARMmbed/mbed-edge.git;protocol=https; \
            file://edge-core.init \
            file://edge-core.service \
            file://edge-core.logrotate \

--- a/recipes-wigwag/mbed-edge-examples/mbed-edge-examples.bb
+++ b/recipes-wigwag/mbed-edge-examples/mbed-edge-examples.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=1dece7821bf3fd70fe1309eaa3
 # Patches for quilt goes to files directory
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://git@github.com/ARMmbed/mbed-edge-examples.git;protocol=ssh; \
+SRC_URI = "git://git@github.com/ARMmbed/mbed-edge-examples.git;protocol=https; \
            file://pt-example \
            file://blept-example \
            file://blept-devices.json \

--- a/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
+++ b/recipes-wigwag/mbed-fcc/mbed-fcc_0.0.1.bb
@@ -14,7 +14,7 @@ PR = "r0"
 
 SRCREV = "dc3862efd6e7b3cbc6f10f34673c76e6fd968a3a"
 
-SRC_URI = "git://git@github.com/ARMmbed/factory-configurator-client-example.git;protocol=ssh;; \
+SRC_URI = "git://git@github.com/ARMmbed/factory-configurator-client-example.git;protocol=https;; \
 file://0001-fix-build-getting-cross-compiler-iface-setting-to-et.patch \
 "
 S = "${WORKDIR}/git"

--- a/recipes-wigwag/node-6lbr/node-6lbr_1.0.bb
+++ b/recipes-wigwag/node-6lbr/node-6lbr_1.0.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "fb2c5c938bdd297d0015aba904a89c81e84ec5f8"
-SRC_URI="git://git@github.com/armPelionEdge/node-6lbr.git;protocol=ssh;"
+SRC_URI="git://git@github.com/armPelionEdge/node-6lbr.git;protocol=https;"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/node-hotplug/node-hotplug_1.0.bb
+++ b/recipes-wigwag/node-hotplug/node-hotplug_1.0.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "02c29ec4fe39884928946ee13650feb233dea4b1"
-SRC_URI="git://git@github.com/armPelionEdge/node-hotplug.git;protocol=ssh"
+SRC_URI="git://git@github.com/armPelionEdge/node-hotplug.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/node-netkit/node-netkit_1.0.bb
+++ b/recipes-wigwag/node-netkit/node-netkit_1.0.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "9b0c8cb53f3d1c9a70e13d942a941fb6fc970f5c"
-SRC_URI="git://git@github.com/armPelionEdge/node-netkit.git;protocol=ssh;"
+SRC_URI="git://git@github.com/armPelionEdge/node-netkit.git;protocol=https;"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/node-znp/node-znp_1.0.bb
+++ b/recipes-wigwag/node-znp/node-znp_1.0.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "3f287272d965595c4d840ecbce59aab641599f73"
-SRC_URI="git://git@github.com/armPelionEdge/node-znp.git;protocol=ssh"
+SRC_URI="git://git@github.com/armPelionEdge/node-znp.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/strace-plus/strace-plus_1.0.bb
+++ b/recipes-wigwag/strace-plus/strace-plus_1.0.bb
@@ -10,7 +10,7 @@ PKGV = "1.0+git${GITPKGV}"
 PR = "r1"
 
 SRCREV = "748ba45eaf506558671d018a18302877c4b237b7"
-SRC_URI="git://git@github.com/pgbovine/strace-plus.git;protocol=ssh"
+SRC_URI="git://git@github.com/pgbovine/strace-plus.git;protocol=https"
 
 
 S = "${WORKDIR}/git"

--- a/recipes-wigwag/tsb/tsb_0.0.1.bb
+++ b/recipes-wigwag/tsb/tsb_0.0.1.bb
@@ -13,7 +13,7 @@ PR = "r3"
 
 SRCREV = "937224c9eab964877b445da3522e144a7a2c58ac"
 
-SRC_URI = "git://git@github.com/armPelionEdge/tsb-c.git;protocol=ssh"
+SRC_URI = "git://git@github.com/armPelionEdge/tsb-c.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
+++ b/recipes-wigwag/wwrelay-utils/wwrelay-utils_1.0.1.bb
@@ -4,9 +4,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI="\
-  git://git@github.com/armPelionEdge/edge-utils.git;protocol=ssh;name=wwrelay \
-  git://git@github.com/armPelionEdge/edgeos-shell-scripts.git;protocol=ssh;name=dss;destsuffix=git/dss \
-  git://git@github.com/armPelionEdge/node-i2c.git;protocol=ssh;name=node_i2c;destsuffix=git/tempI2C/node-i2c \
+  git://git@github.com/armPelionEdge/edge-utils.git;protocol=https;name=wwrelay \
+  git://git@github.com/armPelionEdge/edgeos-shell-scripts.git;protocol=https;name=dss;destsuffix=git/dss \
+  git://git@github.com/armPelionEdge/node-i2c.git;protocol=https;name=node_i2c;destsuffix=git/tempI2C/node-i2c \
   file://wwrelay \
   file://BUILDMMU.txt \
   file://wwrelay.service \


### PR DESCRIPTION
This will build meta-pelion-edge in the environment where only outbound HTTP/HTTPS is allowed by a firewall.